### PR TITLE
Introduce SEV Offline KBC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,5 @@ default = ["sample_kbc", "offline_fs_kbc"]
 sample_kbc = []
 eaa_kbc = []
 offline_fs_kbc = ["openssl"]
+offline_sev_kbc = ["openssl"]
+

--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ List of supported KBC modules:
 | sample_kbc         | Null                                                                | Null         | Attestation Agent Authors |
 | offline_fs_kbc     | [Offline file system KBC](src/kbc_modules/offline_fs_kbc/README.md) | Null         | IBM                       |
 | eaa_kbc            | [EAA KBC](src/kbc_modules/eaa_kbc/README.md)                        | EAA protocol | Alibaba Cloud             |
+| offline_sev_kbc    | [Offline SEV KBC](src/kbc_modules/offline_sev_kbc/README.md)        | Null         | IBM                       |

--- a/src/kbc_modules/mod.rs
+++ b/src/kbc_modules/mod.rs
@@ -9,6 +9,10 @@
 pub mod eaa_kbc;
 #[cfg(feature = "offline_fs_kbc")]
 pub mod offline_fs_kbc;
+
+#[cfg(feature = "offline_sev_kbc")]
+pub mod offline_sev_kbc;
+
 #[cfg(feature = "sample_kbc")]
 pub mod sample_kbc;
 
@@ -65,6 +69,13 @@ impl KbcModuleList {
                 Box::new(eaa_kbc::EAAKbc::new(kbs_uri))
             });
             mod_list.insert("eaa_kbc".to_string(), instantiate_func);
+        }
+
+        #[cfg(feature = "offline_sev_kbc")]
+        {
+            let instantiate_func: KbcInstantiateFunc =
+                Box::new(|_: String| -> KbcInstance { Box::new(offline_sev_kbc::OfflineSevKbc::new()) });
+            mod_list.insert("offline_sev_kbc".to_string(), instantiate_func);
         }
 
         KbcModuleList { mod_list: mod_list }

--- a/src/kbc_modules/offline_sev_kbc/README.md
+++ b/src/kbc_modules/offline_sev_kbc/README.md
@@ -1,0 +1,44 @@
+# Offline SEV KBC module
+
+This KBC does not communicate with a KBS at runtime, but rather retrieves keys that were injected at boot. This KBC is designed for use with SEV or SEV-ES secret injection and the EFI Secret kernel module, which coordinates with OVMF to expose injected secrets to guest userspace. If you would like to use an offline KBC without secret injection, consider the offline\_fs\_kbc.
+
+## Secret Injection
+
+To use this KBC in conjunction with EFI Secret, you must carefully craft an injected secret. The secret should be a GUIDed secret table.
+
+### Structure of the EFI secret area
+
+```
+  Offset   Length
+  (bytes)  (bytes)  Usage
+  -------  -------  -----
+        0       16  Secret table header GUID (must be 1e74f542-71dd-4d66-963e-ef4287ff173b)
+       16        4  Length of bytes of the entire secret area
+
+       20       16  First secret entry's GUID
+       36        4  First secret entry's length in bytes (= 16 + 4 + x)
+       40        x  First secret entry's data
+
+     40+x       16  Second secret entry's GUID
+     56+x        4  Second secret entry's length in bytes (= 16 + 4 + y)
+     60+x        y  Second secret entry's data
+```
+
+The secret table should include an entry with the GUID `e6f5a162-d67f-4750-a67c-5d065f2a9910`. The contents of this secret should be a JSON file in the following format where each key is 32-bytes and base64 encoded.
+
+```
+{
+    "key_id1": "cGFzc3BocmFzZXdoaWNobmVlZHN0b2JlMzJieXRlcyE=",
+    ...
+}
+```
+
+## Usage
+
+This KBC has no adjustable parameters. The KBC will not function without the EFI Secret module. The module should be available but not loaded before KBC is invoked. The KBC will not be able to unload the module if /proc has not been mounted.
+
+To run:
+
+```
+cargo run --release --no-default-features --features offline_sev_kbc -- --grpc_sock 127.0.0.1:50000
+```

--- a/src/kbc_modules/offline_sev_kbc/mod.rs
+++ b/src/kbc_modules/offline_sev_kbc/mod.rs
@@ -1,0 +1,228 @@
+// Copyright (c) 2021 IBM Corp.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::kbc_modules::{KbcCheckInfo, KbcInterface};
+
+use anyhow::{anyhow, Result};
+use base64::decode;
+use openssl::symm::{decrypt, Cipher};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::process::Command;
+
+const KEYS_PATH: &str = "/sys/kernel/security/coco/efi_secret/e6f5a162-d67f-4750-a67c-5d065f2a9910";
+const SECRET_MODULE_NAME: &str = "efi_secret";
+const MODPROBE_PATH: &str = "/usr/sbin/modprobe";
+const MOUNT_PATH: &str = "/usr/bin/mount";
+
+type Keys = HashMap<String, Vec<u8>>;
+type Ciphers = HashMap<String, Cipher>;
+
+#[derive(Deserialize)]
+pub struct AnnotationPacket {
+    // Key ID to manage multiple keys
+    pub kid: String,
+    // Encrypted key to unwrap
+    pub wrapped_data: Vec<u8>,
+    // Initialisation vector
+    pub iv: Vec<u8>,
+    // Wrap type to specify encryption algorithm and mode
+    pub wrap_type: String,
+}
+
+struct SecretKernelModule;
+
+impl SecretKernelModule {
+    fn new() -> Result<SecretKernelModule> {
+        if !Command::new(MODPROBE_PATH)
+            .arg(SECRET_MODULE_NAME)
+            .status()?
+            .success()
+        {
+            return Err(anyhow!("Failed to load secret module."));
+        }
+        Ok(SecretKernelModule {})
+    }
+}
+impl Drop for SecretKernelModule {
+    fn drop(&mut self) {
+        Command::new(MODPROBE_PATH)
+            .arg("-r")
+            .arg(SECRET_MODULE_NAME)
+            .status()
+            .expect("Failed to unload secret module.");
+    }
+}
+
+pub struct OfflineSevKbc {
+    // KBS info for compatibility; unused
+    kbs_info: HashMap<String, String>,
+    // Stored keys, loaded from file system; load might fail
+    keys: Result<Keys>,
+    // Known ciphers, corresponding to wrap_type
+    ciphers: Ciphers,
+}
+
+fn get_ciphers() -> Ciphers {
+    // The sample KBC uses aes-gcm (Rust implementation). The offline file system KBC uses OpenSSL
+    // instead to get access to hardware acceleration on more platforms (e.g. s390x). As opposed
+    // to aes-gcm, OpenSSL will only allow GCM when using AEAD. Because authentication is not
+    // handled here, AEAD cannot be used, therefore, CTR is used instead.
+    [(String::from("aes_256_ctr"), Cipher::aes_256_ctr())]
+        .iter()
+        .cloned()
+        .collect()
+}
+
+impl KbcInterface for OfflineSevKbc {
+    fn check(&self) -> Result<KbcCheckInfo> {
+        Ok(KbcCheckInfo {
+            kbs_info: self.kbs_info.clone(),
+        })
+    }
+
+    fn decrypt_payload(&mut self, annotation: &str) -> Result<Vec<u8>> {
+        let annotation_packet: AnnotationPacket = serde_json::from_str(annotation)
+            .map_err(|e| anyhow!("Failed to parse annotation: {}", e))?;
+        let kid = annotation_packet.kid;
+        let keys = self.keys.as_ref().map_err(|e| anyhow!("{}", e))?;
+        let key = keys
+            .get(&kid)
+            .ok_or_else(|| anyhow!("Received unknown key ID: {}", kid))?;
+        let iv = annotation_packet.iv;
+        let wrapped_data = annotation_packet.wrapped_data;
+        let wrap_type = annotation_packet.wrap_type;
+
+        let cipher = self
+            .ciphers
+            .get(&wrap_type)
+            .ok_or_else(|| anyhow!("Received unknown wrap type: {}", wrap_type))?;
+        // Redact decryption errors to avoid oracles
+        decrypt(*cipher, key, Some(&iv), &wrapped_data).map_err(|_| anyhow!("Failed to decrypt"))
+    }
+}
+
+impl OfflineSevKbc {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> OfflineSevKbc {
+        OfflineSevKbc {
+            kbs_info: HashMap::new(),
+            keys: load_keys(KEYS_PATH).map_err(|e| anyhow!("Failed to load keys: {}", e)),
+            ciphers: get_ciphers(),
+        }
+    }
+}
+
+// This function panics if it is unable to delete the secret file after it has been read
+// or if it is unable to unload the efi_secret kernel module once it has been loaded.
+// Both of these cases could result in exposing the secret.
+//
+// /sys and /proc should be mounted for this to work correctly.
+fn load_keys(keyfile_name: &str) -> Result<Keys> {
+    mount_security_fs()?;
+    let _secret_module = SecretKernelModule::new()?;
+
+    let keys_json = fs::read_to_string(keyfile_name)?;
+    fs::remove_file(keyfile_name).expect("Failed to remove secret file.");
+
+    // Redact parsing errors to avoid side-channels
+    let encoded_keys: HashMap<String, String> =
+        serde_json::from_str(&keys_json).map_err(|_| anyhow!("Failed to parse keys JSON file"))?;
+
+    encoded_keys
+        .iter()
+        .map(|(k, v)| match decode(v) {
+            Ok(key) => Ok((k.clone(), key)),
+            Err(_) => Err(anyhow!("Failed to decode key")),
+        })
+        .collect()
+}
+
+fn mount_security_fs() -> Result<()> {
+    if !Command::new(MOUNT_PATH)
+        .arg("-t")
+        .arg("securityfs")
+        .arg("securityfs")
+        .arg("/sys/kernel/security")
+        .status()?
+        .success()
+    {
+        return Err(anyhow!("Failed to mount security fs"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use openssl::symm::encrypt;
+
+    const KID: &str = "foo";
+    const KEY: [u8; 32] = *b"passphrasewhichneedstobe32bytes!";
+
+    #[test]
+    fn test_decrypt_payload() {
+        let iv = b"ivmustbe16bytes!";
+        let data = b"bar";
+
+        let cipher_key = "aes_256_ctr";
+        let cipher = get_ciphers().get(cipher_key).unwrap().to_owned();
+        let wrapped_data = encrypt(cipher, &KEY, Some(iv), data).unwrap();
+
+        let annotation = format!(
+            "{{
+    \"kid\": \"{}\",
+    \"wrapped_data\": {:?},
+    \"iv\": {:?},
+    \"wrap_type\": \"{}\"
+}}",
+            KID, wrapped_data, iv, cipher_key
+        );
+
+        let mut kbc = OfflineSevKbc {
+            kbs_info: HashMap::new(),
+            keys: Ok([(KID.to_string(), KEY.to_vec())].iter().cloned().collect()),
+            ciphers: get_ciphers(),
+        };
+
+        assert_eq!(kbc.decrypt_payload(&annotation).unwrap(), data);
+
+        let invalid_annotation = &annotation[..annotation.len() - 1];
+        assert!(kbc.decrypt_payload(invalid_annotation).is_err());
+
+        let mut key_load_failure_kbc = OfflineSevKbc {
+            kbs_info: HashMap::new(),
+            keys: Err(anyhow!("")),
+            ciphers: get_ciphers(),
+        };
+        assert!(key_load_failure_kbc.decrypt_payload(&annotation).is_err());
+
+        let mut unknown_kid_kbc = OfflineSevKbc {
+            kbs_info: HashMap::new(),
+            keys: Ok([(String::from("baz"), KEY.to_vec())]
+                .iter()
+                .cloned()
+                .collect()),
+            ciphers: get_ciphers(),
+        };
+        assert!(unknown_kid_kbc.decrypt_payload(&annotation).is_err());
+
+        // Notice that a valid, but incorrect key does not yield an error
+        let mut invalid_key_kbc = OfflineSevKbc {
+            kbs_info: HashMap::new(),
+            keys: Ok([(
+                KID.to_string(),
+                b"thispassphraseisntactually32bytes".to_vec(),
+            )]
+            .iter()
+            .cloned()
+            .collect()),
+            ciphers: get_ciphers(),
+        };
+        assert!(invalid_key_kbc.decrypt_payload(&annotation).is_err());
+    }
+}


### PR DESCRIPTION
Adapted from `offline_sev_kbc` by @Jakob-Naucke and built on EFI Secret Kernel Module by @dubek. This is a big piece of the answer to confidential-containers/guest-components#249. Works fine retrieving an injected secret from inside an SEV guest.