### PR TITLE
offline_fs_kbs: Do not use dd in generate-keys.sh

### DIFF
--- a/sample_kbs/src/enc_mods/offline_fs_kbs/generate_keys.sh
+++ b/sample_kbs/src/enc_mods/offline_fs_kbs/generate_keys.sh
@@ -4,7 +4,7 @@ declare -A keys
 
 create_keys() {
 	for i in $(seq 1 "$1"); do
-		keys[key_id$i]=$(dd if=/dev/random bs=32 count=1 2> /dev/null | base64)
+		keys[key_id$i]=$(head -c32 < /dev/random | base64)
 	done
 }
 


### PR DESCRIPTION
`dd bs=32 count=1 if=/dev/random` doesn't always do what I thought it
did (the block might not actually get filled and the key will be too
short). Use `head`.

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>