### PR TITLE
EAA KBC: Remove hardcode 'tdx' field

### DIFF
--- a/src/kbc_modules/eaa_kbc/mod.rs
+++ b/src/kbc_modules/eaa_kbc/mod.rs
@@ -81,15 +81,8 @@ impl EAAKbc {
 
     fn establish_new_kbs_connection(&mut self) -> Result<()> {
         debug!("create RATS TLS handle...");
-        self.tls_handle = Some(
-            rats_tls::RatsTls::new(
-                &Some("openssl".to_string()),
-                &Some("openssl".to_string()),
-                &Some("tdx".to_string()),
-                &Some("nullverifier".to_string()),
-            )
-            .map_err(|e| anyhow!("create rats_tls failed!:{:?}", e))?,
-        );
+        self.tls_handle =
+            Some(rats_tls::RatsTls::new().map_err(|e| anyhow!("create rats_tls failed!:{:?}", e))?);
 
         self.tcp_stream = Some(TcpStream::connect(&self.kbs_uri)?);
 

--- a/src/kbc_modules/eaa_kbc/rats_tls/mod.rs
+++ b/src/kbc_modules/eaa_kbc/rats_tls/mod.rs
@@ -68,31 +68,11 @@ impl DerefMut for RatsTls {
 }
 
 impl RatsTls {
-    pub fn new(
-        // tls_type: OpenSSL
-        tls_type: &Option<String>,
-        // crypto: OpenSSL
-        crypto: &Option<String>,
-        // attester: Support tdx now
-        attester: &Option<String>,
-        // verifier: Unused, always set to nullverifier
-        verifier: &Option<String>,
-    ) -> Result<RatsTls, RatsTlsErrT> {
+    pub fn new() -> Result<RatsTls, RatsTlsErrT> {
         let mut conf: rats_tls_conf_t = Default::default();
         conf.api_version = RATS_TLS_API_VERSION_DEFAULT;
         conf.log_level = RATS_TLS_LOG_LEVEL_DEBUG;
-        if let Some(tls_type) = tls_type {
-            conf.tls_type[..tls_type.len()].copy_from_slice(tls_type.as_bytes());
-        }
-        if let Some(crypto) = crypto {
-            conf.crypto_type[..crypto.len()].copy_from_slice(crypto.as_bytes());
-        }
-        if let Some(attester) = attester {
-            conf.attester_type[..attester.len()].copy_from_slice(attester.as_bytes());
-        }
-        if let Some(verifier) = verifier {
-            conf.verifier_type[..verifier.len()].copy_from_slice(verifier.as_bytes());
-        }
+
         conf.cert_algo = RATS_TLS_CERT_ALGO_DEFAULT;
         conf.enclave_id = 0;
         conf.flags |= RATS_TLS_CONF_FLAGS_MUTUAL;

--- a/src/kbc_modules/mod.rs
+++ b/src/kbc_modules/mod.rs
@@ -73,8 +73,9 @@ impl KbcModuleList {
 
         #[cfg(feature = "offline_sev_kbc")]
         {
-            let instantiate_func: KbcInstantiateFunc =
-                Box::new(|_: String| -> KbcInstance { Box::new(offline_sev_kbc::OfflineSevKbc::new()) });
+            let instantiate_func: KbcInstantiateFunc = Box::new(|_: String| -> KbcInstance {
+                Box::new(offline_sev_kbc::OfflineSevKbc::new())
+            });
             mod_list.insert("offline_sev_kbc".to_string(), instantiate_func);
         }
 


### PR DESCRIPTION
The rats-tls relied on by EAA KBC adds the function of automatic detection platform and selecting appropriate attester (rats-tls PR#1452: https://github.com/alibaba/inclavare-containers/pull/1452 ）Therefore, we no longer need to hard code the parameter ‘tdx’ attester in EAA KBC.