### PR TITLE
agent: Simplify code using TryFrom trait

### DIFF
--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -5,6 +5,8 @@
 
 use anyhow::*;
 use log::*;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 use std::net::SocketAddr;
 use std::str;
 use std::sync::Arc;
@@ -20,8 +22,30 @@ pub mod key_provider {
     tonic::include_proto!("keyprovider");
 }
 
+pub const AGENT_NAME: &str = "attestation-agent";
+
+const ERR_ANNOTATION_NOT_BASE64: &str = "annotation is not base64 encoded";
+const ERR_DC_EMPTY: &str = "missing Dc value";
+const ERR_KBC_KBS_NOT_BASE64: &str = "KBC/KBS pair not base64 encoded";
+const ERR_KBC_KBS_NOT_FOUND: &str = "KBC/KBS pair not found";
+const ERR_NO_KBC_NAME: &str = "missing KBC name";
+const ERR_NO_KBS_URI: &str = "missing KBS URI";
+const ERR_WRONG_DC_PARAM: &str = "Dc parameter not destined for agent";
+
+const KBC_KBS_PAIR_SEP: &str = "::";
+
 #[derive(Debug, Default)]
 pub struct KeyProvider {}
+
+impl TryFrom<Vec<u8>> for InputPayload {
+    type Error = anyhow::Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let input = KeyProviderInput::try_from(bytes)?;
+
+        InputPayload::try_from(input)
+    }
+}
 
 #[tonic::async_trait]
 impl KeyProviderService for KeyProvider {
@@ -31,29 +55,30 @@ impl KeyProviderService for KeyProvider {
     ) -> Result<Response<KeyProviderKeyWrapProtocolOutput>, Status> {
         debug!("The UnWrapKey API is called...");
 
-        // Deserialize and parse the gRPC input to get KBC name, KBS uri and annotation.
-        let input_payload: InputPayload = parse_input(
-            request.into_inner().key_provider_key_wrap_protocol_input,
-        )
-        .map_err(|e| {
-            error!("Parse request failed: {}", e);
-            Status::internal(format!(
-                "[ERROR:attestation-agent] Parse request failed: {}",
-                e
-            ))
-        })?;
+        // Deserialize and parse the gRPC input to get KBC name, KBS URI and annotation.
+        let input_payload =
+            InputPayload::try_from(request.into_inner().key_provider_key_wrap_protocol_input)
+                .map_err(|e| {
+                    error!("Parse request failed: {}", e);
+                    Status::internal(format!(
+                        "[ERROR:{}] Parse request failed: {}",
+                        AGENT_NAME, e
+                    ))
+                })?;
 
-        // Pass the KBC name, KBS uri and annotation to the KBC instance for content parsing and field decryption.
+        // Pass the KBC name, KBS uri and annotation to the KBC instance for
+        // content parsing and field decryption.
         let kbc_runtime_mutex_clone = Arc::clone(&kbc_runtime::KBC_RUNTIME);
         let mut kbc_runtime = kbc_runtime_mutex_clone.lock().map_err(|e| {
             error!("Get KBC runtime MUTEX failed: {}", e);
             Status::internal(format!(
-                "[ERROR:attestation-agent] Get KBC runtime failed: {}",
-                e
+                "[ERROR:{}] Get KBC runtime failed: {}",
+                AGENT_NAME, e
             ))
         })?;
 
         debug!("Call KBC to decrypt...");
+
         let decrypted_optsdata = kbc_runtime
             .decrypt(
                 input_payload.kbc_name,
@@ -63,10 +88,11 @@ impl KeyProviderService for KeyProvider {
             .map_err(|e| {
                 error!("Call KBC to decrypt failed: {}", e);
                 Status::internal(format!(
-                    "[ERROR:attestation-agent] KBC decryption failed: {}",
-                    e
+                    "[ERROR:{}] KBC decryption failed: {}",
+                    AGENT_NAME, e
                 ))
             })?;
+
         debug!("Decrypted successfully, get the plain PLBCO");
 
         // Construct output structure and serialize it as the return value of gRPC
@@ -75,6 +101,7 @@ impl KeyProviderService for KeyProvider {
                 optsdata: decrypted_optsdata,
             },
         };
+
         let output = serde_json::to_string(&output_struct)
             .unwrap()
             .as_bytes()
@@ -99,60 +126,105 @@ impl KeyProviderService for KeyProvider {
     ) -> Result<Response<KeyProviderKeyWrapProtocolOutput>, Status> {
         debug!("The WrapKey API is called...");
         debug!("WrapKey API is unimplemented!");
-        Err(Status::unimplemented(
-            "WrapKey API of attestation-agent is unimplemented!",
-        ))
+        Err(Status::unimplemented(format!(
+            "WrapKey API of {} is unimplemented!",
+            AGENT_NAME,
+        )))
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 struct InputPayload {
     kbc_name: String,
+    // Note: URI does *not* contain a scheme prefix.
     kbs_uri: String,
     annotation: String,
 }
 
-fn parse_input(input_byte: Vec<u8>) -> Result<InputPayload> {
-    let input_string = String::from_utf8(input_byte)?;
-    debug!("UnWrapKey API Request Input: {}", input_string);
-    let input: KeyProviderInput = serde_json::from_str::<KeyProviderInput>(&input_string)?;
-    let base64_annotation = input
-        .keyunwrapparams
-        .annotation
-        .ok_or_else(|| anyhow!("The annotation field in the input is Empty!"))?;
-    let vec_annotation = base64::decode(base64_annotation)?;
-    let jsonstring_annotation: &str = str::from_utf8(&vec_annotation)?;
-    let dc = input
-        .keyunwrapparams
-        .dc
-        .ok_or_else(|| anyhow!("The Dc field in the input is None!"))?;
+impl TryFrom<KeyProviderInput> for InputPayload {
+    type Error = anyhow::Error;
 
-    /*
-     * AA expects the received DC parameter format is:
-     * "dc":{
-     *     "Parameters":{
-     *         "attestation_agent":["< KBC_NAME::KBS_URI (base64encode) >"]
-     *     }
-     * }
-     */
-    let parameters_list = dc.parameters.get("attestation-agent").ok_or(anyhow!(
-        "Invalid parameters: the request is not sent to attention agent!"
-    ))?;
-    let kbc_kbs_pair_byte = base64::decode(parameters_list[0].clone())?;
-    let kbc_kbs_pair = std::str::from_utf8(&kbc_kbs_pair_byte)?;
-    if let Some(index) = kbc_kbs_pair.find("::") {
-        let kbc_name: String = kbc_kbs_pair[..index].to_string();
-        let kbs_uri: String = kbc_kbs_pair[(index + 2)..].to_string();
-        debug!("Get KBC_NAME:{}, KBS_URI:{}", kbc_name, kbs_uri);
-        Ok(InputPayload {
+    fn try_from(kpi: KeyProviderInput) -> Result<Self, Self::Error> {
+        /*
+         * AA expects the received DC parameter format is:
+         * "dc":{
+         *     "Parameters":{
+         *         "attestation-agent":["< KBC_NAME::KBS_URI (base64encode) >"]
+         *     }
+         * }
+         */
+
+        let annotation = get_annotation(&kpi)?;
+
+        let (kbc_name, kbs_uri) = get_kbc_kbs_pair(&kpi)?;
+
+        let payload = InputPayload {
             kbc_name,
             kbs_uri,
-            annotation: jsonstring_annotation.to_string(),
-        })
+            annotation,
+        };
+
+        Ok(payload)
+    }
+}
+
+fn get_annotation(kpi: &KeyProviderInput) -> Result<String> {
+    let base64_annotation = kpi
+        .keyunwrapparams
+        .annotation
+        .as_ref()
+        .ok_or_else(|| anyhow!(ERR_ANNOTATION_EMPTY))?;
+
+    let vec_annotation = base64::decode(base64_annotation)
+        .map_err(|e| anyhow!("{}: {:?}", ERR_ANNOTATION_NOT_BASE64, e))?;
+
+    let annotation: &str = str::from_utf8(&vec_annotation)?;
+
+    if annotation.is_empty() {
+        return Err(anyhow!(ERR_ANNOTATION_EMPTY));
+    }
+
+    Ok(annotation.into())
+}
+
+fn get_kbc_kbs_pair(kpi: &KeyProviderInput) -> Result<(String, String)> {
+    let dc = kpi
+        .keyunwrapparams
+        .dc
+        .as_ref()
+        .ok_or_else(|| anyhow!(ERR_DC_EMPTY))?;
+
+    if let Some(parameters_list) = dc.parameters.get(AGENT_NAME) {
+        let value = if let Some(value) = parameters_list.get(0) {
+            value
+        } else {
+            return Err(anyhow!(ERR_DC_EMPTY));
+        };
+
+        let kbc_kbs_pair_byte = base64::decode(value.clone())
+            .map_err(|e| anyhow!("{}: {:?}", ERR_KBC_KBS_NOT_BASE64, e))?;
+
+        let kbc_kbs_value = std::str::from_utf8(&kbc_kbs_pair_byte)?;
+
+        Ok(str_to_kbc_kbs(kbc_kbs_value)?)
     } else {
-        return Err(anyhow!(
-            "Invalid parameters: invalid {} pair format!",
-            kbc_kbs_pair
-        ));
+        Err(anyhow!(ERR_WRONG_DC_PARAM))
+    }
+}
+
+fn str_to_kbc_kbs(value: &str) -> Result<(String, String)> {
+    if let Some((kbc_name, kbs_uri)) = value.split_once(KBC_KBS_PAIR_SEP) {
+        if kbc_name.is_empty() {
+            return Err(anyhow!(ERR_NO_KBC_NAME));
+        }
+
+        if kbs_uri.is_empty() {
+            return Err(anyhow!(ERR_NO_KBS_URI));
+        }
+
+        Ok((kbc_name.to_string(), kbs_uri.to_string()))
+    } else {
+        Err(anyhow!(ERR_KBC_KBS_NOT_FOUND))
     }
 }
 
@@ -163,4 +235,495 @@ pub async fn start_service(socket: SocketAddr) -> Result<()> {
         .serve(socket)
         .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grpc::protocol::keyprovider_structs::{
+        ERR_INVALID_OP, ERR_MISSING_OP, ERR_UNSUPPORTED_OP, ERR_UNWRAP_PARAMS_NO_DC,
+    };
+    use base64::encode;
+
+    #[test]
+    fn test_get_annotation() {
+        #[derive(Debug)]
+        struct TestData<'a> {
+            annotation: Option<&'a str>,
+            result: Result<String>,
+        }
+
+        let valid_annotation = "valid annotation";
+        let encoded_annotation = base64::encode(valid_annotation);
+
+        let tests = &[
+            TestData {
+                annotation: None,
+                result: Err(anyhow!(ERR_ANNOTATION_EMPTY)),
+            },
+            TestData {
+                annotation: Some(""),
+                result: Err(anyhow!(ERR_ANNOTATION_EMPTY)),
+            },
+            TestData {
+                annotation: Some("."),
+                result: Err(anyhow!(ERR_ANNOTATION_NOT_BASE64)),
+            },
+            TestData {
+                annotation: Some("a"),
+                result: Err(anyhow!(ERR_ANNOTATION_NOT_BASE64)),
+            },
+            TestData {
+                annotation: Some(&encoded_annotation),
+                result: Ok(valid_annotation.into()),
+            },
+        ];
+
+        for (i, d) in tests.iter().enumerate() {
+            // Create a string containing details of the test
+            let msg = format!("test[{}]: {:?}", i, d);
+
+            let annotation_string = d.annotation.map(String::from);
+
+            let mut kpi = KeyProviderInput::default();
+            kpi.keyunwrapparams.annotation = annotation_string;
+
+            let result = get_annotation(&kpi);
+
+            let msg = format!("{}: result: {:?}", msg, result);
+
+            if d.result.is_err() {
+                assert!(result.is_err(), "{}", msg);
+
+                let expected_error = format!("{:?}", d.result.as_ref().err().unwrap());
+                let actual_error = format!("{:?}", result.err().unwrap());
+
+                assert!(actual_error.starts_with(&expected_error), "{}", msg);
+            } else {
+                assert!(result.is_ok(), "{}", msg);
+
+                let expected_result = d.result.as_ref().unwrap();
+                let actual_result = result.unwrap();
+
+                assert_eq!(expected_result, &actual_result, "{}", msg);
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_kbc_kbs_pair() {
+        #[derive(Debug)]
+        struct TestData {
+            dc: Option<Dc>,
+            result: Result<(String, String)>,
+        }
+
+        let kbc_name = "kbc-name";
+        let kbs_uri = "https://kbs.uri.com";
+
+        let annotation_value = format!("{}::{}", kbc_name, kbs_uri);
+        let annotation_base64 = encode(annotation_value.clone());
+
+        let mut invalid_dc_not_base64: Dc = Dc::default();
+        invalid_dc_not_base64
+            .parameters
+            .insert(AGENT_NAME.into(), vec![annotation_value]);
+
+        let mut invalid_dc_wrong_name: Dc = Dc::default();
+        invalid_dc_wrong_name
+            .parameters
+            .insert("foo bar".into(), vec![annotation_base64.clone()]);
+
+        let mut valid_dc: Dc = Dc::default();
+        valid_dc
+            .parameters
+            .insert(AGENT_NAME.into(), vec![annotation_base64]);
+
+        let tests = &[
+            TestData {
+                dc: None,
+                result: Err(anyhow!(ERR_DC_EMPTY)),
+            },
+            TestData {
+                dc: Some(Dc::default()),
+                result: Err(anyhow!(ERR_WRONG_DC_PARAM)),
+            },
+            TestData {
+                dc: Some(invalid_dc_not_base64),
+                result: Err(anyhow!(ERR_KBC_KBS_NOT_BASE64)),
+            },
+            TestData {
+                dc: Some(invalid_dc_wrong_name),
+                result: Err(anyhow!(ERR_WRONG_DC_PARAM)),
+            },
+            TestData {
+                dc: Some(valid_dc),
+                result: Ok((kbc_name.into(), kbs_uri.into())),
+            },
+        ];
+
+        for (i, d) in tests.iter().enumerate() {
+            // Create a string containing details of the test
+            let msg = format!("test[{}]: {:?}", i, d);
+
+            let mut kpi = KeyProviderInput::default();
+            kpi.keyunwrapparams.dc = d.dc.clone();
+
+            let result = get_kbc_kbs_pair(&kpi);
+
+            let msg = format!("{}: result: {:?}", msg, result);
+
+            if d.result.is_err() {
+                assert!(result.is_err(), "{}", msg);
+
+                let expected_error = format!("{:?}", d.result.as_ref().err().unwrap());
+                let actual_error = format!("{:?}", result.err().unwrap());
+
+                assert!(actual_error.starts_with(&expected_error), "{}", msg);
+            } else {
+                assert!(result.is_ok(), "{}", msg);
+
+                let expected_result = d.result.as_ref().unwrap();
+                let actual_result = result.unwrap();
+
+                assert_eq!(expected_result, &actual_result, "{}", msg);
+            }
+        }
+    }
+
+    #[test]
+    fn test_input_payload() {
+        #[derive(Debug)]
+        struct TestData {
+            input: KeyProviderInput,
+            result: Result<InputPayload>,
+        }
+
+        let mut invalid_dc = Dc::default();
+
+        invalid_dc
+            .parameters
+            .insert("foo".into(), vec!["bar".into(), "baz".into()]);
+
+        let mut invalid_dc_not_base64 = Dc::default();
+
+        invalid_dc_not_base64
+            .parameters
+            .insert(AGENT_NAME.into(), vec![".".into(), "a".into()]);
+
+        let mut valid_dc: Dc = Dc::default();
+
+        let kbc_name = "kbc-name";
+        let kbs_uri = "https://kbs.uri.com";
+
+        let annotation_value = format!("{}::{}", kbc_name, kbs_uri);
+
+        let annotation_base64 = encode(annotation_value);
+
+        valid_dc
+            .parameters
+            .insert(AGENT_NAME.into(), vec![annotation_base64]);
+
+        let valid_result = InputPayload {
+            kbc_name: kbc_name.into(),
+            kbs_uri: kbs_uri.into(),
+            annotation: AGENT_NAME.into(),
+        };
+
+        let tests = &[
+            TestData {
+                input: KeyProviderInput::default(),
+                result: Err(anyhow!(ERR_ANNOTATION_EMPTY)),
+            },
+            TestData {
+                input: KeyProviderInput::default()
+                    // Lie and pretend this is overly short base64 encoding is base64 data
+                    .with_key_unwrap_params(
+                        KeyUnwrapParams::default().with_base64_annotation("a".into()),
+                    ),
+                result: Err(anyhow!(ERR_ANNOTATION_NOT_BASE64)),
+            },
+            TestData {
+                input: KeyProviderInput::default()
+                    // Lie and pretend this is invalid byte is base64 data
+                    .with_key_unwrap_params(
+                        KeyUnwrapParams::default().with_base64_annotation(".".into()),
+                    ),
+                result: Err(anyhow!(ERR_ANNOTATION_NOT_BASE64)),
+            },
+            TestData {
+                input: KeyProviderInput::default().with_key_unwrap_params(
+                    KeyUnwrapParams::default().with_annotation(AGENT_NAME.into()),
+                ),
+                result: Err(anyhow!(ERR_DC_EMPTY)),
+            },
+            TestData {
+                input: KeyProviderInput::default()
+                    .with_key_unwrap_params(KeyUnwrapParams::default().with_dc(invalid_dc.clone())),
+                result: Err(anyhow!(ERR_ANNOTATION_EMPTY)),
+            },
+            TestData {
+                input: KeyProviderInput::default().with_key_unwrap_params(
+                    KeyUnwrapParams::default()
+                        .with_dc(invalid_dc_not_base64.clone())
+                        .with_annotation(AGENT_NAME.into()),
+                ),
+                result: Err(anyhow!(ERR_KBC_KBS_NOT_BASE64)),
+            },
+            TestData {
+                input: KeyProviderInput::default().with_key_unwrap_params(
+                    KeyUnwrapParams::default()
+                        .with_dc(invalid_dc.clone())
+                        .with_annotation(AGENT_NAME.into()),
+                ),
+                result: Err(anyhow!(ERR_WRONG_DC_PARAM)),
+            },
+            TestData {
+                input: KeyProviderInput::default().with_key_unwrap_params(
+                    KeyUnwrapParams::default()
+                        .with_dc(valid_dc.clone())
+                        .with_annotation(AGENT_NAME.into()),
+                ),
+                result: Ok(valid_result),
+            },
+        ];
+
+        for (i, d) in tests.iter().enumerate() {
+            // Create a string containing details of the test
+            let msg = format!("test[{}]: {:?}", i, d);
+
+            let result = InputPayload::try_from(d.input.clone());
+
+            let msg = format!("{}: result: {:?}", msg, result);
+
+            if d.result.is_err() {
+                assert!(result.is_err(), "{}", msg);
+
+                let expected_error = format!("{:?}", d.result.as_ref().err().unwrap());
+                let actual_error = format!("{:?}", result.err().unwrap());
+
+                assert!(actual_error.starts_with(&expected_error), "{}", msg);
+            } else {
+                assert!(result.is_ok(), "{}", msg);
+
+                let expected_result = d.result.as_ref().unwrap();
+                let actual_result = result.unwrap();
+
+                assert_eq!(expected_result, &actual_result, "{}", msg);
+            }
+        }
+    }
+
+    #[test]
+    fn test_input_payload_try_from() {
+        #[derive(Debug)]
+        struct TestData {
+            input: Vec<u8>,
+            result: Result<InputPayload>,
+        }
+
+        let serde_eof_error = "EOF while parsing a value at line 1 column 0";
+
+        let default_input = KeyProviderInput::default();
+        let default_key_unwrap_params = KeyUnwrapParams::default();
+
+        let kbc_name = "kbc-name";
+
+        // Note: no URI scheme used
+        let kbs_uri = "eaa_kbc::127.0.0.1:1122";
+
+        let annotation = "annotation".to_string();
+
+        let annotation_value = format!("{}::{}", kbc_name, kbs_uri);
+
+        let annotation_base64 = encode(annotation_value);
+
+        let mut valid_dc: Dc = Dc::default();
+
+        valid_dc
+            .parameters
+            .insert(AGENT_NAME.into(), vec![annotation_base64]);
+
+        let valid_key_unwrap_params = KeyUnwrapParams::default()
+            .with_dc(valid_dc)
+            .with_annotation(annotation.clone());
+
+        // valid input
+        let valid_key_provider_input = default_input
+            .clone()
+            .with_op("keyunwrap".into())
+            .with_key_unwrap_params(valid_key_unwrap_params);
+
+        // valid output
+        let valid_input_payload = InputPayload {
+            kbc_name: kbc_name.into(),
+            kbs_uri: kbs_uri.into(),
+            annotation,
+        };
+
+        let default_serialised = serde_json::to_string(&default_input).unwrap();
+
+        let valid_serialised = serde_json::to_string(&valid_key_provider_input).unwrap();
+
+        let invalid_op = "invalid";
+        let input_invalid_op = default_input.clone().with_op(invalid_op.into());
+        let invalid_op_serialised = serde_json::to_string(&input_invalid_op).unwrap();
+
+        let unsupported_op = OP_KEY_WRAP;
+        let input_unsupported_op = default_input.clone().with_op(unsupported_op.into());
+        let unsupported_op_serialised = serde_json::to_string(&input_unsupported_op).unwrap();
+
+        let supported_op = OP_KEY_UNWRAP;
+
+        let input_op_no_unwrap_params = default_input.clone().with_op(supported_op.into());
+        let op_no_unwrap_params_serialised =
+            serde_json::to_string(&input_op_no_unwrap_params).unwrap();
+
+        let input_op_with_empty_unwrap_params = default_input
+            .with_op(supported_op.into())
+            .with_key_unwrap_params(default_key_unwrap_params);
+
+        let op_with_empty_unwrap_params_serialised =
+            serde_json::to_string(&input_op_with_empty_unwrap_params).unwrap();
+
+        let tests = &[
+            TestData {
+                input: Vec::<u8>::new(),
+                result: Err(anyhow!(serde_eof_error)),
+            },
+            TestData {
+                input: "".as_bytes().to_vec(),
+                result: Err(anyhow!(serde_eof_error)),
+            },
+            TestData {
+                input: "foo bar".as_bytes().to_vec(),
+                result: Err(anyhow!("expected ident at line 1 column 2")),
+            },
+            TestData {
+                input: default_serialised.as_bytes().to_vec(),
+                result: Err(anyhow!(ERR_MISSING_OP)),
+            },
+            TestData {
+                input: invalid_op_serialised.as_bytes().to_vec(),
+                result: Err(anyhow!("{}: {:?}", ERR_INVALID_OP, invalid_op)),
+            },
+            TestData {
+                input: unsupported_op_serialised.as_bytes().to_vec(),
+                result: Err(anyhow!("{}: {:?}", ERR_UNSUPPORTED_OP, unsupported_op)),
+            },
+            TestData {
+                input: op_no_unwrap_params_serialised.as_bytes().to_vec(),
+                result: Err(anyhow!("{}", ERR_UNWRAP_PARAMS_NO_DC)),
+            },
+            TestData {
+                input: op_with_empty_unwrap_params_serialised.as_bytes().to_vec(),
+                result: Err(anyhow!("{}", ERR_UNWRAP_PARAMS_NO_DC)),
+            },
+            TestData {
+                input: valid_serialised.as_bytes().to_vec(),
+                result: Ok(valid_input_payload),
+            },
+        ];
+
+        for (i, d) in tests.iter().enumerate() {
+            // Create a string containing details of the test
+            let msg = format!("test[{}]: {:?}", i, d);
+
+            let result = InputPayload::try_from(d.input.clone());
+
+            let msg = format!("{}: result: {:?}", msg, result);
+
+            if d.result.is_err() {
+                assert!(result.is_err(), "{}", msg);
+
+                let expected_error = format!("{:?}", d.result.as_ref().err().unwrap());
+                let actual_error = format!("{:?}", result.err().unwrap());
+
+                assert!(actual_error.starts_with(&expected_error), "{}", msg);
+            } else {
+                assert!(result.is_ok(), "{}", msg);
+
+                let expected_result = d.result.as_ref().unwrap();
+                let actual_result = result.unwrap();
+
+                assert_eq!(expected_result, &actual_result, "{}", msg);
+            }
+        }
+    }
+
+    #[test]
+    fn test_str_to_kbc_kbs() {
+        #[derive(Debug)]
+        struct TestData<'a> {
+            value: &'a str,
+            result: Result<(String, String)>,
+        }
+
+        let tests = &[
+            TestData {
+                value: "",
+                result: Err(anyhow!(ERR_KBC_KBS_NOT_FOUND)),
+            },
+            TestData {
+                value: ":",
+                result: Err(anyhow!(ERR_KBC_KBS_NOT_FOUND)),
+            },
+            TestData {
+                value: "::",
+                result: Err(anyhow!(ERR_NO_KBC_NAME)),
+            },
+            TestData {
+                value: ":::",
+                result: Err(anyhow!(ERR_NO_KBC_NAME)),
+            },
+            TestData {
+                value: "foo",
+                result: Err(anyhow!(ERR_KBC_KBS_NOT_FOUND)),
+            },
+            TestData {
+                value: "foo::",
+                result: Err(anyhow!(ERR_NO_KBS_URI)),
+            },
+            TestData {
+                value: "::foo",
+                result: Err(anyhow!(ERR_NO_KBC_NAME)),
+            },
+            TestData {
+                value: "foo::https://foo.bar.com/?silly=yes&colons=bar:::baz:::wibble::",
+                result: Ok((
+                    "foo".into(),
+                    "https://foo.bar.com/?silly=yes&colons=bar:::baz:::wibble::".into(),
+                )),
+            },
+            TestData {
+                value: "eaa_kbc::127.0.0.1:1122",
+                result: Ok(("eaa_kbc".into(), "127.0.0.1:1122".into())),
+            },
+        ];
+
+        for (i, d) in tests.iter().enumerate() {
+            // Create a string containing details of the test
+            let msg = format!("test[{}]: {:?}", i, d);
+
+            let result = str_to_kbc_kbs(d.value);
+
+            let msg = format!("{}: result: {:?}", msg, result);
+
+            if d.result.is_err() {
+                assert!(result.is_err(), "{}", msg);
+
+                let expected_error = format!("{:?}", d.result.as_ref().err().unwrap());
+                let actual_error = format!("{:?}", result.err().unwrap());
+
+                assert!(actual_error.starts_with(&expected_error), "{}", msg);
+            } else {
+                assert!(result.is_ok(), "{}", msg);
+
+                let expected_result = d.result.as_ref().unwrap();
+                let actual_result = result.unwrap();
+
+                assert_eq!(expected_result, &actual_result, "{}", msg);
+            }
+        }
+    }
 }

--- a/src/grpc/protocol/keyprovider_structs.rs
+++ b/src/grpc/protocol/keyprovider_structs.rs
@@ -3,11 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::str;
 use std::vec::Vec;
 
-#[derive(Serialize, Deserialize, Debug)]
+pub const ERR_INVALID_OP: &str = "invalid operator";
+pub const ERR_ANNOTATION_EMPTY: &str = "annotation cannot be empty";
+pub const ERR_MISSING_OP: &str = "missing operator";
+pub const ERR_UNSUPPORTED_OP: &str = "unsupported operator";
+pub const ERR_UNWRAP_PARAMS_NO_ANNOTATION: &str = "keyunwrap parameters must include annotation";
+pub const ERR_UNWRAP_PARAMS_NO_DC: &str = "keyunwrap parameters must include Dc";
+pub const ERR_WRAP_PARAMS_EXPECT_EMPTY_EC: &str = "keywrap parameters should not include Ec";
+pub const ERR_WRAP_PARAMS_EXPECT_EMPTY_OPTSDATA: &str =
+    "keywrap parameters should not include optsdata";
+pub const OP_KEY_UNWRAP: &str = "keyunwrap";
+pub const OP_KEY_WRAP: &str = "keywrap";
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct KeyProviderInput {
     // Operation is either "keywrap" or "keyunwrap"
     // attestation-agent can only handle the case of "keyunwrap"
@@ -17,7 +32,60 @@ pub struct KeyProviderInput {
     pub keyunwrapparams: KeyUnwrapParams,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+impl KeyProviderInput {
+    pub fn valid(&self) -> Result<()> {
+        match self.op.as_str() {
+            OP_KEY_WRAP => Err(anyhow!(
+                "{}: {:?}: {}",
+                ERR_UNSUPPORTED_OP,
+                self.op,
+                "use a different key provider to encrypt images"
+            )),
+            OP_KEY_UNWRAP => Ok(()),
+            "" => Err(anyhow!(ERR_MISSING_OP)),
+            _ => Err(anyhow!("{}: {:?}", ERR_INVALID_OP, self.op)),
+        }?;
+
+        self.keywrapparams.valid()?;
+        self.keyunwrapparams.valid()?;
+
+        Ok(())
+    }
+
+    pub fn with_op(self, op: String) -> Self {
+        KeyProviderInput { op, ..self }
+    }
+
+    pub fn with_key_wrap_params(self, params: KeyWrapParams) -> Self {
+        KeyProviderInput {
+            keywrapparams: params,
+            ..self
+        }
+    }
+
+    pub fn with_key_unwrap_params(self, params: KeyUnwrapParams) -> Self {
+        KeyProviderInput {
+            keyunwrapparams: params,
+            ..self
+        }
+    }
+}
+
+impl TryFrom<Vec<u8>> for KeyProviderInput {
+    type Error = anyhow::Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let input_string = String::from_utf8(bytes)?;
+
+        let input: KeyProviderInput = serde_json::from_str::<KeyProviderInput>(&input_string)?;
+
+        input.valid()?;
+
+        Ok(input)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct KeyWrapParams {
     // For attestation-agent, ec is null
     pub ec: Option<Ec>,
@@ -25,7 +93,47 @@ pub struct KeyWrapParams {
     pub optsdata: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+impl KeyWrapParams {
+    pub fn valid(&self) -> Result<()> {
+        let ec_empty = if let Some(ec) = self.ec.clone() {
+            ec.empty()
+        } else {
+            true
+        };
+
+        if !ec_empty {
+            return Err(anyhow!(ERR_WRAP_PARAMS_EXPECT_EMPTY_EC));
+        }
+
+        let optsdata_empty = if let Some(ref optsdata) = self.optsdata {
+            optsdata.is_empty()
+        } else {
+            true
+        };
+
+        if !optsdata_empty {
+            return Err(anyhow!(ERR_WRAP_PARAMS_EXPECT_EMPTY_OPTSDATA));
+        }
+
+        Ok(())
+    }
+
+    pub fn with_ec(self, ec: Ec) -> Self {
+        KeyWrapParams {
+            ec: Some(ec),
+            ..self
+        }
+    }
+
+    pub fn with_opts_data(self, data: String) -> Self {
+        KeyWrapParams {
+            optsdata: Some(data),
+            ..self
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
 pub struct Ec {
     #[serde(rename = "Parameters")]
     pub parameters: HashMap<String, Vec<String>>,
@@ -33,16 +141,75 @@ pub struct Ec {
     pub decrypt_config: Dc,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+impl Ec {
+    pub fn empty(self) -> bool {
+        self.parameters.is_empty() && self.decrypt_config.empty()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct KeyUnwrapParams {
     pub dc: Option<Dc>,
     pub annotation: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+impl KeyUnwrapParams {
+    pub fn valid(&self) -> Result<()> {
+        // "empty" means "not defined" or "not set"
+        let dc_empty = if let Some(dc) = self.dc.clone() {
+            dc.empty()
+        } else {
+            true
+        };
+
+        if dc_empty {
+            return Err(anyhow!(ERR_UNWRAP_PARAMS_NO_DC));
+        }
+
+        let annotation_empty = if let Some(ref annotation) = self.annotation {
+            annotation.is_empty()
+        } else {
+            true
+        };
+
+        if annotation_empty {
+            return Err(anyhow!(ERR_UNWRAP_PARAMS_NO_ANNOTATION));
+        }
+
+        Ok(())
+    }
+
+    pub fn with_dc(self, dc: Dc) -> Self {
+        KeyUnwrapParams {
+            dc: Some(dc),
+            ..self
+        }
+    }
+
+    pub fn with_base64_annotation(self, base64_annotation: String) -> Self {
+        KeyUnwrapParams {
+            annotation: Some(base64_annotation),
+            ..self
+        }
+    }
+
+    pub fn with_annotation(self, annotation: String) -> Self {
+        self.with_base64_annotation(base64::encode(annotation))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
 pub struct Dc {
+    // Name is expected to be AGENT_NAME.
+    // Values are expected to be base-64 encoded.
     #[serde(rename = "Parameters")]
     pub parameters: HashMap<String, Vec<String>>,
+}
+
+impl Dc {
+    pub fn empty(self) -> bool {
+        self.parameters.is_empty()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -63,4 +230,296 @@ pub struct KeyUnwrapOutput {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct KeyUnwrapResults {
     pub optsdata: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grpc::AGENT_NAME;
+    use base64::encode;
+
+    #[test]
+    fn test_key_wrap_params_valid() {
+        #[derive(Debug)]
+        struct TestData {
+            ec: Option<Ec>,
+            opts: Option<String>,
+            result: Result<()>,
+        }
+
+        let tests = &[
+            TestData {
+                ec: None,
+                opts: None,
+                result: Ok(()),
+            },
+            TestData {
+                ec: Some(Ec::default()),
+                opts: Some("".into()),
+                result: Ok(()),
+            },
+            TestData {
+                ec: None,
+                opts: Some("foo".into()),
+                result: Err(anyhow!("{}", ERR_WRAP_PARAMS_EXPECT_EMPTY_OPTSDATA)),
+            },
+            TestData {
+                ec: Some(Ec::default()),
+                opts: None,
+                result: Ok(()),
+            },
+            TestData {
+                ec: Some(Ec::default()),
+                opts: Some("foo".into()),
+                result: Err(anyhow!("{}", ERR_WRAP_PARAMS_EXPECT_EMPTY_OPTSDATA)),
+            },
+            TestData {
+                ec: None,
+                opts: Some("".into()),
+                result: Ok(()),
+            },
+        ];
+
+        for (i, d) in tests.iter().enumerate() {
+            // Create a string containing details of the test
+            let msg = format!("test[{}]: {:?}", i, d);
+
+            let mut params = KeyWrapParams::default();
+
+            if let Some(ec) = d.ec.clone() {
+                params = params.with_ec(ec);
+            }
+
+            if let Some(opts) = d.opts.clone() {
+                params = params.with_opts_data(opts);
+            }
+
+            let result = params.valid();
+
+            let msg = format!("{}: result: {:?}", msg, result);
+
+            if d.result.is_err() {
+                assert!(result.is_err(), "{}", msg);
+
+                let expected_error = format!("{:?}", d.result.as_ref().err().unwrap());
+                let actual_error = format!("{:?}", result.err().unwrap());
+
+                assert!(actual_error.starts_with(&expected_error), "{}", msg);
+            } else {
+                assert!(result.is_ok(), "{}", msg);
+
+                let expected_result = d.result.as_ref().unwrap();
+                let actual_result = result.unwrap();
+
+                assert_eq!(expected_result, &actual_result, "{}", msg);
+            }
+        }
+    }
+
+    #[test]
+    fn test_key_unwrap_params_valid() {
+        #[derive(Debug)]
+        struct TestData {
+            dc: Option<Dc>,
+            annotation: Option<String>,
+            result: Result<()>,
+        }
+
+        let kbc_name = "kbc-name";
+        let kbs_uri = "kbs-uri";
+
+        let annotation_value = format!("{}::{}", kbc_name, kbs_uri);
+
+        let annotation_base64 = encode(annotation_value);
+
+        let mut valid_dc: Dc = Dc::default();
+        valid_dc
+            .parameters
+            .insert(AGENT_NAME.into(), vec![annotation_base64]);
+
+        let tests = &[
+            TestData {
+                dc: None,
+                annotation: None,
+                result: Err(anyhow!(ERR_UNWRAP_PARAMS_NO_DC)),
+            },
+            TestData {
+                dc: Some(Dc::default()),
+                annotation: None,
+                result: Err(anyhow!(ERR_UNWRAP_PARAMS_NO_DC)),
+            },
+            TestData {
+                dc: None,
+                annotation: Some("".into()),
+                result: Err(anyhow!(ERR_UNWRAP_PARAMS_NO_DC)),
+            },
+            TestData {
+                dc: Some(valid_dc.clone()),
+                annotation: None,
+                result: Err(anyhow!(ERR_UNWRAP_PARAMS_NO_ANNOTATION)),
+            },
+            TestData {
+                dc: Some(valid_dc.clone()),
+                annotation: Some("".into()),
+                result: Err(anyhow!(ERR_UNWRAP_PARAMS_NO_ANNOTATION)),
+            },
+            TestData {
+                dc: Some(valid_dc.clone()),
+                annotation: Some("foo".into()),
+                result: Ok(()),
+            },
+        ];
+
+        for (i, d) in tests.iter().enumerate() {
+            // Create a string containing details of the test
+            let msg = format!("test[{}]: {:?}", i, d);
+
+            let mut params = KeyUnwrapParams::default();
+
+            if let Some(dc) = d.dc.clone() {
+                params = params.with_dc(dc);
+            }
+
+            if let Some(an) = d.annotation.clone() {
+                params = params.with_annotation(an);
+            }
+
+            let result = params.valid();
+
+            let msg = format!("{}: result: {:?}", msg, result);
+
+            if d.result.is_err() {
+                assert!(result.is_err(), "{}", msg);
+
+                let expected_error = format!("{:?}", d.result.as_ref().err().unwrap());
+                let actual_error = format!("{:?}", result.err().unwrap());
+
+                assert!(actual_error.starts_with(&expected_error), "{}", msg);
+            } else {
+                assert!(result.is_ok(), "{}", msg);
+
+                let expected_result = d.result.as_ref().unwrap();
+                let actual_result = result.unwrap();
+
+                assert_eq!(expected_result, &actual_result, "{}", msg);
+            }
+        }
+    }
+
+    #[test]
+    fn test_key_provider_input() {
+        #[derive(Debug)]
+        struct TestData {
+            input: Vec<u8>,
+            result: Result<KeyProviderInput>,
+        }
+
+        let serde_eof_error = "EOF while parsing a value at line 1 column 0";
+
+        let default_input = KeyProviderInput::default();
+        let default_key_unwrap_params = KeyUnwrapParams::default();
+
+        let default_serialised = serde_json::to_string(&default_input).unwrap();
+
+        let invalid_op = "invalid";
+        let input_invalid_op = default_input.clone().with_op(invalid_op.into());
+        let invalid_op_serialised = serde_json::to_string(&input_invalid_op).unwrap();
+
+        let unsupported_op = OP_KEY_WRAP;
+        let input_unsupported_op = default_input.clone().with_op(unsupported_op.into());
+        let unsupported_op_serialised = serde_json::to_string(&input_unsupported_op).unwrap();
+
+        let supported_op = OP_KEY_UNWRAP;
+
+        let input_op_no_unwrap_params = default_input.clone().with_op(supported_op.into());
+        let op_no_unwrap_params_serialised =
+            serde_json::to_string(&input_op_no_unwrap_params).unwrap();
+
+        let input_op_with_empty_unwrap_params = default_input
+            .with_op(supported_op.into())
+            .with_key_unwrap_params(default_key_unwrap_params);
+
+        let op_with_empty_unwrap_params_serialised =
+            serde_json::to_string(&input_op_with_empty_unwrap_params).unwrap();
+
+        let mut valid_dc: Dc = Dc::default();
+
+        valid_dc
+            .parameters
+            .insert("foo".into(), vec!["bar".into(), "baz".into()]);
+
+        let valid_key_unwrap_params = KeyUnwrapParams::default()
+            .with_dc(valid_dc)
+            .with_annotation("annotation".into());
+
+        // valid input
+        let valid_key_provider_input = KeyProviderInput::default()
+            .with_op("keyunwrap".into())
+            .with_key_unwrap_params(valid_key_unwrap_params);
+
+        let valid_serialised = serde_json::to_string(&valid_key_provider_input).unwrap();
+        let tests = &[
+            TestData {
+                input: Vec::<u8>::new(),
+                result: Err(anyhow!(serde_eof_error)),
+            },
+            TestData {
+                input: "".as_bytes().to_vec(),
+                result: Err(anyhow!(serde_eof_error)),
+            },
+            TestData {
+                input: "foo bar".as_bytes().to_vec(),
+                result: Err(anyhow!("expected ident at line 1 column 2")),
+            },
+            TestData {
+                input: default_serialised.as_bytes().to_vec(),
+                result: Err(anyhow!(ERR_MISSING_OP)),
+            },
+            TestData {
+                input: invalid_op_serialised.as_bytes().to_vec(),
+                result: Err(anyhow!("{}: {:?}", ERR_INVALID_OP, invalid_op)),
+            },
+            TestData {
+                input: unsupported_op_serialised.as_bytes().to_vec(),
+                result: Err(anyhow!("{}: {:?}", ERR_UNSUPPORTED_OP, unsupported_op)),
+            },
+            TestData {
+                input: op_no_unwrap_params_serialised.as_bytes().to_vec(),
+                result: Err(anyhow!("{}", ERR_UNWRAP_PARAMS_NO_DC)),
+            },
+            TestData {
+                input: op_with_empty_unwrap_params_serialised.as_bytes().to_vec(),
+                result: Err(anyhow!("{}", ERR_UNWRAP_PARAMS_NO_DC)),
+            },
+            TestData {
+                input: valid_serialised.as_bytes().to_vec(),
+                result: Ok(valid_key_provider_input),
+            },
+        ];
+
+        for (i, d) in tests.iter().enumerate() {
+            // Create a string containing details of the test
+            let msg = format!("test[{}]: {:?}", i, d);
+
+            let result = KeyProviderInput::try_from(d.input.clone());
+
+            let msg = format!("{}: result: {:?}", msg, result);
+
+            if d.result.is_err() {
+                assert!(result.is_err(), "{}", msg);
+
+                let expected_error = format!("{:?}", d.result.as_ref().err().unwrap());
+                let actual_error = format!("{:?}", result.err().unwrap());
+
+                assert!(actual_error.starts_with(&expected_error), "{}", msg);
+            } else {
+                assert!(result.is_ok(), "{}", msg);
+
+                let expected_result = d.result.as_ref().unwrap();
+                let actual_result = result.unwrap();
+
+                assert_eq!(expected_result, &actual_result, "{}", msg);
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,15 +17,13 @@ pub mod kbc_runtime;
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
-    let app_matches = App::new("attestation-agent")
+    let app_matches = App::new(grpc::AGENT_NAME)
         .version("1.0.0")
         .arg(
             Arg::with_name("socket addr")
                 .long("grpc_sock")
                 .takes_value(true)
-                .help(
-                    "The socket address which the grpc service will listen to, 
-                    for example: --grpc_sock 127.0.0.1:11223",
+                .help("The socket address which the grpc service will listen to, for example: --grpc_sock 127.0.0.1:11223",
                 ),
         )
         .get_matches();


### PR DESCRIPTION
Simplified `parse_input()` drastically by implementing `TryFrom` for
`InputPayload` and `KeyProviderInput`.

Also refactored error handling and added lots of unit tests.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>