### PR TITLE
CI: Add rustfmt to offline_sev_kbc job

### DIFF
--- a/.github/workflows/offline_sev_kbc.yml
+++ b/.github/workflows/offline_sev_kbc.yml
@@ -34,6 +34,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+          components: rustfmt
 
       - name: Build and install with offline_sev_kbc feature
         run: |


### PR DESCRIPTION
Signed-off-by: Dov Murik <dovmurik@linux.ibm.com>

---

This should solve the CI issues we see in Nightly and Beta in #33 :

```
error: 'rustfmt' is not installed for the toolchain 'nightly-x86_64-unknown-linux-gnu'
```
