### PR TITLE
Fix: src/grpc/mod.rs: expected struct `Status`, found struct `anyhow:Error`.

### DIFF
--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -117,7 +117,7 @@ impl KeyProviderService for KeyProvider {
         };
         debug!("Reply successfully!");
 
-        Ok(Response::new(reply))
+        Result::Ok(Response::new(reply))
     }
 
     async fn wrap_key(


### PR DESCRIPTION
After the version of rust is updated, the following problems will occur when compiling AA:
```shell
# make KBC=sample_kbc
cargo build --release --no-default-features --features sample_kbc 
   Compiling attestation-agent v1.0.0 (/root/xinjian/attestation-agent)
error[E0308]: mismatched types
   --> src/grpc/mod.rs:120:9
    |
120 |         Ok(Response::new(reply))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Status`, found struct `anyhow::Error`
    |
    = note: expected enum `std::result::Result<_, Status>`
               found enum `std::result::Result<_, anyhow::Error>`
note: return type inferred to be `std::result::Result<tonic::Response<KeyProviderKeyWrapProtocolOutput>, Status>` here
   --> src/grpc/mod.rs:55:69
    |
55  |       ) -> Result<Response<KeyProviderKeyWrapProtocolOutput>, Status> {
    |  _____________________________________________________________________^
56  | |         debug!("The UnWrapKey API is called...");
57  | |
58  | |         // Deserialize and parse the gRPC input to get KBC name, KBS URI and annotation.
...   |
120 | |         Ok(Response::new(reply))
121 | |     }
    | |_____^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `attestation-agent`

To learn more, run the command again with --verbose.
make: *** [Makefile:48: build] Error 101
```

The commit in this PR will fix this bug.