### PR TITLE
makefile: do not remove Cargo.lock on `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ uninstall:
 	rm -f $(DESTDIR)/$(BIN_NAME)
 
 clean:
-	cargo clean && rm -f Cargo.lock
+	cargo clean
 
 help:
 	@echo "==========================Help============================="


### PR DESCRIPTION
The commit 1f3e58da2b97349b28a3ed4c added Cargo.lock in version
control so we should not delete that file on `make clean`

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>