### PR TITLE
sample_kbs: add instruction to copy image to localhost

### DIFF
--- a/sample_kbs/README.md
+++ b/sample_kbs/README.md
@@ -29,6 +29,12 @@ vim ocicrypt.conf:
 }
 ```
 
+Copy the image you want to encrypt to your current directory. This example uses a *busybox* image:
+
+```
+skopeo copy docker://busybox oci:busybox
+```
+
 Encrypt the container image. You can pass in the special parameters required by the encryption module through the command line parameters of skopeo (here, the string "test" is taken as an exemplary special parameter): 
 
 ```


### PR DESCRIPTION
On sample_kbs's README tell how to copy an image to the current directory
as it might not be obvious to newcomers.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>