### PR TITLE
build: support building attestation agent for s390x

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Musl build with default features
         run: |
           make LIBC=musl
+      
+      - name: s390x build with default features
+        run:
+          make ARCH=s390x
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -33,9 +33,9 @@ jobs:
         run: |
           make LIBC=musl
       
-      - name: s390x build with default features
+      - name: s390x build with offline_fs_kbc feature
         run:
-          make ARCH=s390x
+          make ARCH=s390x KBC=offline_fs_kbc
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/offline_sev_kbc.yml
+++ b/.github/workflows/offline_sev_kbc.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Musl build with offline_sev_kbc feature
         run: |
           make LIBC=musl KBC=offline_sev_kbc
+    
+      - name: s390x build with offline_sev_kbc feature
+        run: |
+          make ARCH=s390x KBC=offline_sev_kbc
 
       - name: Run cargo test with offline_sev_kbc feature
         uses: actions-rs/cargo@v1

--- a/.github/workflows/offline_sev_kbc.yml
+++ b/.github/workflows/offline_sev_kbc.yml
@@ -41,10 +41,6 @@ jobs:
       - name: Musl build with offline_sev_kbc feature
         run: |
           make LIBC=musl KBC=offline_sev_kbc
-    
-      - name: s390x build with offline_sev_kbc feature
-        run: |
-          make ARCH=s390x KBC=offline_sev_kbc
 
       - name: Run cargo test with offline_sev_kbc feature
         uses: actions-rs/cargo@v1

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,12 @@ ifeq ($(KBC), eaa_kbc)
     RUSTFLAGS_ARGS += -C link-args=-Wl,-rpath,/usr/local/lib/rats-tls
 endif
 
+ifeq ($(KBC), offline_sev_kbc)
+    ifeq ($(ARCH), s390x)
+        $(error ERROR: Offline SEV KBC does not support s390x architecture!)
+    endif
+endif
+
 ifneq ($(RUSTFLAGS_ARGS),)
     RUST_FLAGS := RUSTFLAGS="$(RUSTFLAGS_ARGS)"
 endif

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,6 @@ KBC ?=
 DESTDIR ?= $(PREFIX)/bin
 RUSTFLAGS_ARGS ?=
 
-PROTOC_S390X_VERSION := 21.1
-PROTOC_S390X_ARCHIVE := protoc-$(PROTOC_S390X_VERSION)-linux-s390_64.zip
-
 ifdef KBC
     feature := --no-default-features --features
 endif
@@ -49,7 +46,7 @@ ifneq ($(SOURCE_ARCH), $(ARCH))
 endif
 
 ifeq ($(SOURCE_ARCH), s390x)
-    PROTOC_BINARY_INSTALL := $(shell wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_S390X_VERSION}/${PROTOC_S390X_ARCHIVE} && unzip -u ${PROTOC_S390X_ARCHIVE} && sudo cp bin/protoc /usr/local/bin/ && rm -f ${PROTOC_S390X_ARCHIVE})
+    PROTOC_BINARY_INSTALL := $(shell sudo apt-get install -y protobuf-compiler)
 endif
 
 LIBC_FLAG := --target $(ARCH)-unknown-linux-$(LIBC)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ KBC ?=
 DESTDIR ?= $(PREFIX)/bin
 RUSTFLAGS_ARGS ?=
 
-PROTOC_S390X_VERSION := v21.1
+PROTOC_S390X_VERSION := 21.1
 PROTOC_S390X_ARCHIVE := protoc-$(PROTOC_S390X_VERSION)-linux-s390_64.zip
 
 ifdef KBC
@@ -49,7 +49,7 @@ ifneq ($(SOURCE_ARCH), $(ARCH))
 endif
 
 ifeq ($(SOURCE_ARCH), s390x)
-    PROTOC_BINARY_INSTALL := $(shell wget https://github.com/protocolbuffers/protobuf/releases/download/${PROTOC_S390X_VERSION}/${PROTOC_S390X_ARCHIVE} && unzip -u ${PROTOC_S390X_ARCHIVE} && sudo cp bin/protoc /usr/local/bin/ && rm -f ${PROTOC_S390X_ARCHIVE})
+    PROTOC_BINARY_INSTALL := $(shell wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_S390X_VERSION}/${PROTOC_S390X_ARCHIVE} && unzip -u ${PROTOC_S390X_ARCHIVE} && sudo cp bin/protoc /usr/local/bin/ && rm -f ${PROTOC_S390X_ARCHIVE})
 endif
 
 LIBC_FLAG := --target $(ARCH)-unknown-linux-$(LIBC)

--- a/Makefile
+++ b/Makefile
@@ -9,23 +9,43 @@ DEBIANOS := $(shell cat /etc/debian_version 2> /dev/null)
 TARGET_DIR := target
 BIN_NAME := attestation-agent
 
+SOURCE_ARCH := $(shell uname -m)
+
+ARCH ?= $(shell uname -m)
 DEBUG ?=
-LIBC ?=
+LIBC ?= gnu
 KBC ?=
 DESTDIR ?= $(PREFIX)/bin
+RUSTFLAGS_ARGS ?=
 
 ifdef KBC
     feature := --no-default-features --features
 endif
 
+ifeq ($(ARCH), s390x)
+    $(error ERROR: Attestation agent does not support building for the musl libc target for s390x architecture)
+endif
+
 ifeq ($(LIBC), musl)
-    MUSL_ADD := $(shell rustup target add x86_64-unknown-linux-musl)
+    MUSL_ADD := $(shell rustup target add ${ARCH}-unknown-linux-musl)
     ifneq ($(DEBIANOS),)
         MUSL_INSTALL := $(shell sudo apt-get install -y musl-tools) 
     endif
-    LIBC_FLAG := --target x86_64-unknown-linux-musl
-    TARGET_DIR := $(TARGET_DIR)/x86_64-unknown-linux-musl
 endif
+
+ifneq ($(SOURCE_ARCH), $(ARCH))
+    ifneq ($(DEBIANOS),)
+        GCC_COMPILER_FOR_TARGET_ARCH := gcc-$(ARCH)-linux-$(LIBC)
+        GCC_FOR_TARGET_ARCH_INSTALL := $(shell sudo apt-get install -y ${GCC_COMPILER_FOR_TARGET_ARCH})
+        RUST_TARGET_FOR_TARGET_ARCH_INSTALL := $(shell rustup target add ${ARCH}-unknown-linux-${LIBC})
+        RUSTFLAGS_ARGS += -C linker=$(GCC_COMPILER_FOR_TARGET_ARCH)
+    else
+        $(error ERROR: Cross-compiling is only tested on Debian-like OSes)
+    endif
+endif
+
+LIBC_FLAG := --target $(ARCH)-unknown-linux-$(LIBC)
+TARGET_DIR := $(TARGET_DIR)/$(ARCH)-unknown-linux-$(LIBC)
 
 ifdef DEBUG
     release :=
@@ -39,12 +59,19 @@ ifeq ($(KBC), eaa_kbc)
     ifeq ($(LIBC), musl)
         $(error ERROR: EAA KBC does not support MUSL build!)
     endif
+    ifeq ($(ARCH), s390x)
+        $(error ERROR: EAA KBC does not support s390x architecture!)
+    endif
     RATS_TLS := $(shell ls /usr/local/lib/rats-tls/ 2> /dev/null)
     ifeq ($(RATS_TLS),)
         RATS_TLS_DOWNLOAD := $(shell cd .. && rm -rf inclavare-containers && git clone https://github.com/alibaba/inclavare-containers)
         RATS_TLS_INSTALL := $(shell cd ../inclavare-containers/rats-tls && cmake -DBUILD_SAMPLES=on -H. -Bbuild && make -C build install >&2)
     endif
-    RUST_FLAGS := RUSTFLAGS="-C link-args=-Wl,-rpath,/usr/local/lib/rats-tls"
+    RUSTFLAGS_ARGS += -C link-args=-Wl,-rpath,/usr/local/lib/rats-tls
+endif
+
+ifneq ($(RUSTFLAGS_ARGS),)
+    RUST_FLAGS := RUSTFLAGS="$(RUSTFLAGS_ARGS)"
 endif
 
 build:
@@ -62,6 +89,6 @@ clean:
 	cargo clean
 
 help:
-	@echo "==========================Help============================="
-	@echo "build: make [DEBUG=1] [LIBC=(musl)] [KBC=xxx_kbc]"
+	@echo "==========================Help========================================="
+	@echo "build: make [DEBUG=1] [LIBC=(musl)] [ARCH=(x86_64/s390x)] [KBC=xxx_kbc]"
 	@echo "install: make install [DESTDIR=/path/to/target] [LIBC=(musl)]"

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,16 @@ KBC ?=
 DESTDIR ?= $(PREFIX)/bin
 RUSTFLAGS_ARGS ?=
 
+PROTOC_S390X_VERSION := v21.1
+PROTOC_S390X_ARCHIVE := protoc-$(PROTOC_S390X_VERSION)-linux-s390_64.zip
+
 ifdef KBC
     feature := --no-default-features --features
 endif
 
 ifeq ($(LIBC), musl)
     ifeq ($(ARCH), s390x)
-        $(error ERROR: Attestation agent does not support building for the musl libc target for s390x architecture)
+        $(error ERROR: Attestation agent does not support building with the musl libc target for s390x architecture!)
     endif
     MUSL_ADD := $(shell rustup target add ${ARCH}-unknown-linux-musl)
     ifneq ($(DEBIANOS),)
@@ -46,7 +49,7 @@ ifneq ($(SOURCE_ARCH), $(ARCH))
 endif
 
 ifeq ($(SOURCE_ARCH), s390x)
-    PROTOC_BINARY_INSTALL := $(shell wget https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-linux-s390_64.zip && unzip protoc-21.1-linux-s390_64.zip && sudo cp bin/protoc /usr/local/bin/)
+    PROTOC_BINARY_INSTALL := $(shell wget https://github.com/protocolbuffers/protobuf/releases/download/${PROTOC_S390X_VERSION}/${PROTOC_S390X_ARCHIVE} && unzip -u ${PROTOC_S390X_ARCHIVE} && sudo cp bin/protoc /usr/local/bin/ && rm -f ${PROTOC_S390X_ARCHIVE})
 endif
 
 LIBC_FLAG := --target $(ARCH)-unknown-linux-$(LIBC)

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,11 @@ endif
 
 ifneq ($(SOURCE_ARCH), $(ARCH))
     ifneq ($(DEBIANOS),)
-        GCC_COMPILER_FOR_TARGET_ARCH := gcc-$(ARCH)-linux-$(LIBC)
-        GCC_FOR_TARGET_ARCH_INSTALL := $(shell sudo apt-get install -y ${GCC_COMPILER_FOR_TARGET_ARCH})
-        RUST_TARGET_FOR_TARGET_ARCH_INSTALL := $(shell rustup target add ${ARCH}-unknown-linux-${LIBC})
+        GCC_COMPILER_PACKAGE_FOR_TARGET_ARCH := gcc-$(ARCH)-linux-$(LIBC)
+        GCC_COMPILER_FOR_TARGET_ARCH := $(ARCH)-linux-$(LIBC)-gcc
+        RUSTC_TARGET_FOR_TARGET_ARCH := $(ARCH)-unknown-linux-$(LIBC)
+        GCC_FOR_TARGET_ARCH_INSTALL := $(shell sudo apt-get install -y ${GCC_COMPILER_PACKAGE_FOR_TARGET_ARCH})
+        RUST_TARGET_FOR_TARGET_ARCH_INSTALL := $(shell rustup target add ${RUSTC_TARGET_FOR_TARGET_ARCH})
         RUSTFLAGS_ARGS += -C linker=$(GCC_COMPILER_FOR_TARGET_ARCH)
     else
         $(error ERROR: Cross-compiling is only tested on Debian-like OSes)

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,10 @@ ifdef KBC
     feature := --no-default-features --features
 endif
 
-ifeq ($(ARCH), s390x)
-    $(error ERROR: Attestation agent does not support building for the musl libc target for s390x architecture)
-endif
-
 ifeq ($(LIBC), musl)
+    ifeq ($(ARCH), s390x)
+        $(error ERROR: Attestation agent does not support building for the musl libc target for s390x architecture)
+    endif
     MUSL_ADD := $(shell rustup target add ${ARCH}-unknown-linux-musl)
     ifneq ($(DEBIANOS),)
         MUSL_INSTALL := $(shell sudo apt-get install -y musl-tools) 
@@ -42,6 +41,10 @@ ifneq ($(SOURCE_ARCH), $(ARCH))
     else
         $(error ERROR: Cross-compiling is only tested on Debian-like OSes)
     endif
+endif
+
+ifeq ($(SOURCE_ARCH), s390x)
+    PROTOC_BINARY_INSTALL := $(shell wget https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-linux-s390_64.zip && unzip protoc-21.1-linux-s390_64.zip && sudo cp bin/protoc /usr/local/bin/)
 endif
 
 LIBC_FLAG := --target $(ARCH)-unknown-linux-$(LIBC)


### PR DESCRIPTION
Support building attestation agent for s390x via cross-compilation
on x86_64 (Debian-based) os.

Support native build for attestation agent for s390x.

Links to issues

* https://github.com/confidential-containers/guest-components/issues/237
* https://github.com/confidential-containers/guest-components/issues/236