### PR TITLE
Tweaks for first release with 5.19 kernel

### DIFF
--- a/src/kbc_modules/offline_sev_kbc/README.md
+++ b/src/kbc_modules/offline_sev_kbc/README.md
@@ -40,6 +40,6 @@ This KBC has no adjustable parameters. The KBC will not function without the EFI
 To run:
 
 ```
-make KBS=offline_sev_kbc && make install
+make KBC=offline_sev_kbc && make install
 attestation-agent --keyprovider_sock 127.0.0.1:47777 --getresource_sock 127.0.0.1:48888
 ```

--- a/src/kbc_modules/offline_sev_kbc/README.md
+++ b/src/kbc_modules/offline_sev_kbc/README.md
@@ -1,6 +1,6 @@
 # Offline SEV KBC module
 
-This KBC does not communicate with a KBS at runtime, but rather retrieves keys that were injected at boot. This KBC is designed for use with SEV or SEV-ES secret injection and the EFI Secret kernel module, which coordinates with OVMF to expose injected secrets to guest userspace. If you would like to use an offline KBC without secret injection, consider the offline\_fs\_kbc.
+This KBC does not communicate with a KBS at runtime, but rather retrieves keys that were injected at boot. This KBC is designed for use with SEV or SEV-ES secret injection and the [EFI Secret](https://docs.kernel.org/security/secrets/coco.html) kernel module, which coordinates with OVMF to expose injected secrets to guest userspace. If you would like to use an offline KBC without secret injection, consider the offline\_fs\_kbc.
 
 ## Secret Injection
 
@@ -35,7 +35,8 @@ The secret table should include an entry with the GUID `e6f5a162-d67f-4750-a67c-
 
 ## Usage
 
-This KBC has no adjustable parameters. The KBC will not function without the EFI Secret module. The module should be available but not loaded before KBC is invoked. The KBC will not be able to unload the module if /proc has not been mounted.
+This KBC has no adjustable parameters. The KBC will not function without the EFI Secret module. The EFI Secret module is supported by the 5.19 or newer kernel.
+The module should be available but not loaded before KBC is invoked. The KBC will not be able to unload the module if /proc has not been mounted.
 
 To run:
 

--- a/src/kbc_modules/offline_sev_kbc/mod.rs
+++ b/src/kbc_modules/offline_sev_kbc/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::process::Command;
 
-const KEYS_PATH: &str = "/sys/kernel/security/coco/efi_secret/e6f5a162-d67f-4750-a67c-5d065f2a9910";
+const KEYS_PATH: &str = "/sys/kernel/security/secrets/coco/e6f5a162-d67f-4750-a67c-5d065f2a9910";
 const SECRET_MODULE_NAME: &str = "efi_secret";
 const MODPROBE_PATH: &str = "/usr/sbin/modprobe";
 const MOUNT_PATH: &str = "/usr/bin/mount";

--- a/src/kbc_modules/offline_sev_kbc/mod.rs
+++ b/src/kbc_modules/offline_sev_kbc/mod.rs
@@ -16,8 +16,8 @@ use std::process::Command;
 
 const KEYS_PATH: &str = "/sys/kernel/security/secrets/coco/e6f5a162-d67f-4750-a67c-5d065f2a9910";
 const SECRET_MODULE_NAME: &str = "efi_secret";
-const MODPROBE_PATH: &str = "/usr/sbin/modprobe";
-const MOUNT_PATH: &str = "/usr/bin/mount";
+const MODPROBE_PATH: &str = "/sbin/modprobe";
+const MOUNT_PATH: &str = "/bin/mount";
 
 type Keys = HashMap<String, Vec<u8>>;
 type Ciphers = HashMap<String, Cipher>;

--- a/src/kbc_modules/online_sev_kbc/README.md
+++ b/src/kbc_modules/online_sev_kbc/README.md
@@ -3,7 +3,7 @@
 This KBC extends the `offline_sev_kbc` to support requests made at runtime.
 This KBC is designed to be used with [simple-kbs](https://github.com/confidential-containers/simple-kbs).
 Since this KBC is an extension of the `offline_sev_kbc` it has many similar properties.
-For instance, it only supports SEV(-ES) and requires an injected secret and the `efi_secret` kernel module.
+For instance, it only supports SEV(-ES) and requires an injected secret and the [EFI Secret](https://docs.kernel.org/security/secrets/coco.html) kernel module.
 The injected secret should be a `connection` secret from the `simple-kbs` and should have the guid `1ee27366-0c87-43a6-af48-28543eaf7cb0`.
 This injected connection contains a symmetric key that is used to encrypt and verify online requests made by the KBC.
 Specifically, the connection is defined in the `Connection` struct as a `client_id` UUID and a `key` string. The key string should be a base64-encoded 256-bit key.
@@ -14,7 +14,8 @@ The connection is protected by the SEV(-ES) secret injection process, which prov
 
 ## Usage
 
-This KBC expects a `KBS_URI` parameter. The KBC will not function without the EFI Secret module. The module should be available but not loaded before KBC is invoked. The KBC will not be able to unload the module if /proc has not been mounted.
+This KBC expects a `KBS_URI` parameter. The KBC will not function without the EFI Secret module. The EFI Secret module is supported by the 5.19 or newer kernel.
+The module should be available but not loaded before KBC is invoked. The KBC will not be able to unload the module if /proc has not been mounted.
 
 To run:
 

--- a/src/kbc_modules/online_sev_kbc/README.md
+++ b/src/kbc_modules/online_sev_kbc/README.md
@@ -19,6 +19,6 @@ This KBC expects a `KBS_URI` parameter. The KBC will not function without the EF
 To run:
 
 ```
-make KBS=online_sev_kbc && make install
+make KBC=online_sev_kbc && make install
 attestation-agent --keyprovider_sock 127.0.0.1:47777 --getresource_sock 127.0.0.1:48888
 ```

--- a/src/kbc_modules/online_sev_kbc/mod.rs
+++ b/src/kbc_modules/online_sev_kbc/mod.rs
@@ -25,7 +25,7 @@ mod getsecret {
     tonic::include_proto!("keybroker");
 }
 
-const KEYS_PATH: &str = "/sys/kernel/security/coco/efi_secret/1ee27366-0c87-43a6-af48-28543eaf7cb0";
+const KEYS_PATH: &str = "/sys/kernel/security/secrets/coco/1ee27366-0c87-43a6-af48-28543eaf7cb0";
 const SECRET_MODULE_NAME: &str = "efi_secret";
 const MODPROBE_PATH: &str = "/usr/sbin/modprobe";
 const MOUNT_PATH: &str = "/usr/bin/mount";

--- a/src/kbc_modules/online_sev_kbc/mod.rs
+++ b/src/kbc_modules/online_sev_kbc/mod.rs
@@ -27,8 +27,8 @@ mod getsecret {
 
 const KEYS_PATH: &str = "/sys/kernel/security/secrets/coco/1ee27366-0c87-43a6-af48-28543eaf7cb0";
 const SECRET_MODULE_NAME: &str = "efi_secret";
-const MODPROBE_PATH: &str = "/usr/sbin/modprobe";
-const MOUNT_PATH: &str = "/usr/bin/mount";
+const MODPROBE_PATH: &str = "/sbin/modprobe";
+const MOUNT_PATH: &str = "/bin/mount";
 
 type Ciphers = HashMap<String, Cipher>;
 


### PR DESCRIPTION
In preparation for the first release, which will use the upstream 5.19 kernel and a Ubuntu 20.04 rootfs for SEV, we need a few minor changes.

@dubek 