### PR TITLE
Sample KBC: delete unused field scheme

### DIFF
--- a/src/kbc_modules/sample_kbc/policy.json
+++ b/src/kbc_modules/sample_kbc/policy.json
@@ -9,7 +9,6 @@
             "quay.io/kata-containers": [
                 {
                     "type": "signedBy",
-                    "scheme": "simple",
                     "keyType": "GPGKeys",
                     "keyPath": "/run/image-security/simple_signing/pubkey.gpg"
                 }


### PR DESCRIPTION
Due to https://github.com/confidential-containers/image-rs/issues/40
in image-rs, the field `scheme` specifying
the signing scheme is abandoned now.

This issue here will block https://github.com/confidential-containers/image-rs/issues/43