### PR TITLE
Fixed port for getresource_sock and keyprovider_sock.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,18 @@ attestation-agent --help
 Start AA and specify the endpoint of AA's gRPC service:
 
 ```shell
-attestation-agent --keyprovider_sock 127.0.0.1:47777 --getresource_sock 127.0.0.1:48888
+attestation-agent --keyprovider_sock 127.0.0.1:50000 --getresource_sock 127.0.0.1:50001
+```
+
+Or start AA with default keyprovider address (127.0.0.1:50000) and default getresource address (127.0.0.1:50001):
+
+```
+attestation-agent
 ```
 
 If you want to see the runtime log:
 ```
-RUST_LOG=attestation_agent attestation-agent --keyprovider_sock 127.0.0.1:47777 --getresource_sock 127.0.0.1:48888
+RUST_LOG=attestation_agent attestation-agent --keyprovider_sock 127.0.0.1:50000 --getresource_sock 127.0.0.1:50001
 ```
 
 ## Supported KBC modules

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -16,6 +16,9 @@ use tokio::sync::Mutex;
 
 mod grpc;
 
+const DEFAULT_KEYPROVIDER_ADDR: &str = "127.0.0.1:50000";
+const DEFAULT_GETRESOURCE_ADDR: &str = "127.0.0.1:50001";
+
 lazy_static! {
     pub static ref ATTESTATION_AGENT: Arc<Mutex<AttestationAgent>> =
         Arc::new(Mutex::new(AttestationAgent::new()));
@@ -44,12 +47,12 @@ async fn main() -> Result<()> {
 
     let keyprovider_socket = app_matches
         .value_of("KeyProvider gRPC socket addr")
-        .unwrap_or("127.0.0.0:44444")
+        .unwrap_or(DEFAULT_KEYPROVIDER_ADDR)
         .parse::<SocketAddr>()?;
 
     let getresource_socket = app_matches
         .value_of("GetResource gRPC socket addr")
-        .unwrap_or("127.0.0.0:55555")
+        .unwrap_or(DEFAULT_GETRESOURCE_ADDR)
         .parse::<SocketAddr>()?;
 
     debug!(


### PR DESCRIPTION
Fix: confidential-containers/guest-components#232

Signed-off-by: Jiale Zhang <zhangjiale@linux.alibaba.com>