### PR TITLE
Fix aes-gcm building failures

### DIFF
--- a/sample_keyprovider/Cargo.toml
+++ b/sample_keyprovider/Cargo.toml
@@ -12,7 +12,7 @@ prost = "0.8"
 futures = "0.3.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-aes-gcm = "0.9.2"
+aes-gcm = "0.10.1"
 base64 = "0.13.0"
 clap = "2"
 anyhow = "1.0"


### PR DESCRIPTION
Bump the version to 0.10.1 to fix some building failures.

Fix: confidential-containers/guest-components#228
Signed-off-by: Jia He <justin.he@arm.com>