### PR TITLE
Extract common SEV code

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) 2022 IBM
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+pub mod sev;

--- a/src/common/sev/mod.rs
+++ b/src/common/sev/mod.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 IBM Corp.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::{anyhow, Result};
+use std::process::Command;
+
+const SECRET_MODULE_NAME: &str = "efi_secret";
+const MODPROBE_PATH: &str = "/sbin/modprobe";
+const MOUNT_PATH: &str = "/bin/mount";
+
+pub struct SecretKernelModule;
+
+impl SecretKernelModule {
+    pub fn new() -> Result<SecretKernelModule> {
+        if !Command::new(MODPROBE_PATH)
+            .arg(SECRET_MODULE_NAME)
+            .status()?
+            .success()
+        {
+            return Err(anyhow!("Failed to load secret module."));
+        }
+        Ok(SecretKernelModule {})
+    }
+}
+impl Drop for SecretKernelModule {
+    fn drop(&mut self) {
+        Command::new(MODPROBE_PATH)
+            .arg("-r")
+            .arg(SECRET_MODULE_NAME)
+            .status()
+            .expect("Failed to unload secret module.");
+    }
+}
+
+pub fn mount_security_fs() -> Result<()> {
+    if !Command::new(MOUNT_PATH)
+        .arg("-t")
+        .arg("securityfs")
+        .arg("securityfs")
+        .arg("/sys/kernel/security")
+        .status()?
+        .success()
+    {
+        return Err(anyhow!("Failed to mount security fs"));
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use anyhow::*;
 use async_trait::async_trait;
 use std::collections::HashMap;
 
+mod common;
 mod kbc_modules;
 
 /// Attestation Agent (AA for short) is a rust library crate for attestation procedure


### PR DESCRIPTION
This pulls out some common code that was duplicated between `offline_sev_kbc` and `online_sev_kbc`.

In the past we have put common code into separate files in the KBC modules. That never really worked very well so I created a new module for shared components that should be a bit more flexible.

Signed-off-by: Tobin Feldman-Fitzthum <tobin@ibm.com>