### PR TITLE
EAA KBC: Fix compile bug of rats-tls callback on TDX.

### DIFF
--- a/src/kbc_modules/eaa_kbc/rats_tls/mod.rs
+++ b/src/kbc_modules/eaa_kbc/rats_tls/mod.rs
@@ -86,7 +86,7 @@ impl RatsTls {
             return Err(err);
         }
 
-        let err = unsafe { rats_tls_set_verification_callback(&mut tls, Some(Self::callback)) };
+        let err = unsafe { rats_tls_set_verification_callback(&mut tls, None) };
         if err == RATS_TLS_ERR_NONE {
             Ok(unsafe { RatsTls::from_ptr(tls) })
         } else {


### PR DESCRIPTION
EAA KBC does not use the callback function of rats-tls, so it can be set to None directly. (If do not do this, errors will occur when compiling on the TDX platform.)