### PR TITLE
Support building on IBM Power

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ ifeq ($(LIBC), musl)
     endif
 endif
 
+ifneq (,$(filter $(ARCH),ppc64le ppc64el))
+    ARCH=powerpc64le
+    SOURCE_ARCH=powerpc64le
+endif
+
 ifneq ($(SOURCE_ARCH), $(ARCH))
     ifneq ($(DEBIANOS),)
         GCC_COMPILER_PACKAGE_FOR_TARGET_ARCH := gcc-$(ARCH)-linux-$(LIBC)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,11 @@ ifeq ($(LIBC), musl)
     endif
 endif
 
-ifneq (,$(filter $(ARCH),ppc64le ppc64el))
+ifeq ($(ARCH),ppc64le)
+    ARCH=powerpc64le
+    SOURCE_ARCH=powerpc64le
+endif
+ifeq ($(ARCH),ppc64el)
     ARCH=powerpc64le
     SOURCE_ARCH=powerpc64le
 endif


### PR DESCRIPTION
The ARCH variable needs to be munged for IBM Power.