### PR TITLE
Introduce Client Id resource 

### DIFF
--- a/src/kbc_modules/cc_kbc/crypto/mod.rs
+++ b/src/kbc_modules/cc_kbc/crypto/mod.rs
@@ -122,7 +122,7 @@ pub fn hash_chunks(chunks: Vec<Vec<u8>>) -> String {
     let mut hasher = Sha384::new();
 
     for chunk in chunks.iter() {
-        hasher.update(&chunk);
+        hasher.update(chunk);
     }
 
     let res = hasher.finalize();

--- a/src/kbc_modules/mod.rs
+++ b/src/kbc_modules/mod.rs
@@ -131,6 +131,8 @@ pub enum ResourceName {
     CosignVerificationKey,
     #[strum(serialize = "Credential")]
     Credential,
+    #[strum(serialize = "Client Id")]
+    ClientId,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
The Client Id resource type allows a guest to request an Id that is provided by the KBS. This can allow a client to more easily associate a particular KBC/workload with a KBS. This value has a somewhat limited use because it cannot be shared publicly. Nonetheless it seems handy and is trivial to implement for SEV.

@dubek 