### PR TITLE
Fix ttrpc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ RUSTFLAGS_ARGS ?=
 features ?=
 OPENSSL ?=
 
+ifeq ($(ARCH), s390x)
+  OPENSSL=1
+endif
+
 ifdef KBC
     features += $(KBC)
 else

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,7 @@ endif
 ifeq ($(ttrpc), true)
     features += ttrpc
 else
-ifeq ($(grpc), true)
     features += grpc
-else
-    features += grpc ttrpc
-endif
 endif
 
 ifeq ($(LIBC), musl)

--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "async-trait",
  "attestation_agent",
  "base64 0.13.1",
+ "cfg-if",
  "clap 3.2.23",
  "env_logger",
  "futures",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0"
 async-trait = "0.1.56"
 attestation_agent = { path = "../", default-features = false }
 base64 = "0.13.0"
+cfg-if = "1.0.0"
 clap = "3.2.5"
 env_logger = "0.9.0"
 futures = "0.3.5"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -6,22 +6,22 @@ publish = false
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.0", default-features = false, features = ["rt-multi-thread"], optional = true }
-tonic = { version = "0.7.2", optional = true }
-prost = { version = "0.10.4", optional = true }
-ttrpc = { version = "0.7.1", optional = true }
-protobuf = { version = "3.1.0", optional = true }
-futures = "0.3.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+anyhow = "1.0"
+async-trait = "0.1.56"
+attestation_agent = { path = "../", default-features = false }
 base64 = "0.13.0"
 clap = "3.2.5"
-anyhow = "1.0"
-log = "0.4.14"
 env_logger = "0.9.0"
+futures = "0.3.5"
 lazy_static = "1.4.0"
-attestation_agent = { path = "../", default-features = false }
-async-trait = "0.1.56"
+log = "0.4.14"
+prost = { version = "0.10.4", optional = true }
+protobuf = { version = "3.1.0", optional = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.0", default-features = false, features = ["rt-multi-thread"], optional = true }
+tonic = { version = "0.7.2", optional = true }
+ttrpc = { version = "0.7.1", optional = true }
 
 [build-dependencies]
 tonic-build = { version = "0.7.2", optional = true }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -12,27 +12,26 @@ use clap::{App, Arg};
 use log::*;
 use std::sync::Arc;
 
-#[cfg(any(
-    not(any(feature = "grpc", feature = "ttrpc")),
-    // all(feature = "grpc", feature = "ttrpc"),
-))]
-compile_error!("One and exactly one feature of `grpc` or `ttrpc` must be enabled.");
-
-mod rpc;
+#[cfg(feature = "ttrpc")]
+mod ttrpc;
 
 #[cfg(feature = "grpc")]
 mod grpc;
-#[cfg(feature = "ttrpc")]
-mod ttrpc;
+
+mod rpc;
 
 fn main() {
     env_logger::init();
 
-    #[cfg(feature = "ttrpc")]
-    ttrpc::ttrpc_main();
-
-    #[cfg(feature = "grpc")]
-    grpc::grpc_main().unwrap();
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "ttrpc")] {
+            ttrpc::ttrpc_main();
+        } else if #[cfg(feature = "grpc")] {
+            grpc::grpc_main().unwrap();
+        } else {
+            compile_error!("one feature of `grpc` or `ttrpc` must be enabled.");
+        }
+    }
 
     loop {}
 }


### PR DESCRIPTION
When both gRPC and ttrpc are enabled, the `keyprovider_sock` and `getresource_sock` parameters will be used in both ttrpc and gRPC configuration. However ttrpc requires a unix socket, while gRPC requires a socket, making the binary crash

```
thread 'main' panicked at 'socket address scheme is not expected', src/ttrpc.rs:78:10
```