### PR TITLE
Update tdx-attest-rs crate for buildgen build fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 [[package]]
 name = "tdx-attest-rs"
 version = "0.1.0"
-source = "git+https://github.com/intel/SGXDataCenterAttestationPrimitives?rev=85cf8bdd#85cf8bdd393ab273a308be3f41d2f7cc25c0ec0c"
+source = "git+https://github.com/intel/SGXDataCenterAttestationPrimitives?rev=cc582e8b#cc582e8be0c9010295c66fb58c59f74744017600"
 dependencies = [
  "tdx-attest-sys",
 ]
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "tdx-attest-sys"
 version = "0.1.0"
-source = "git+https://github.com/intel/SGXDataCenterAttestationPrimitives?rev=85cf8bdd#85cf8bdd393ab273a308be3f41d2f7cc25c0ec0c"
+source = "git+https://github.com/intel/SGXDataCenterAttestationPrimitives?rev=cc582e8b#cc582e8be0c9010295c66fb58c59f74744017600"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = { version = "0.10", optional = true }
 strum = { version = "0.24.0", features = ["derive"] }
-tdx-attest-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", rev = "85cf8bdd", optional = true }
+tdx-attest-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", rev = "cc582e8b", optional = true }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"], optional = true }
 tonic = { version = "0.8.0", optional = true }
 url = "2.3.1"


### PR DESCRIPTION
This pulls in the following fix which affects building the tdx-attest-sys crates when libclang is avilable but clang is not: https://github.com/intel/SGXDataCenterAttestationPrimitives/pull/28