### PR TITLE
feat: Add protocol and KBCs info to `--help` output

### DIFF
--- a/app/src/grpc.rs
+++ b/app/src/grpc.rs
@@ -18,6 +18,7 @@ lazy_static! {
 pub async fn grpc_main() -> Result<()> {
     let app_matches = App::new(rpc::AGENT_NAME)
         .version(env!("CARGO_PKG_VERSION"))
+        .about(rpc::ABOUT.as_str())
         .arg(
             Arg::with_name("KeyProvider gRPC socket addr")
                 .long("keyprovider_sock")

--- a/app/src/rpc/mod.rs
+++ b/app/src/rpc/mod.rs
@@ -12,4 +12,18 @@ pub mod ttrpc_protocol;
 pub type TtrpcService =
     std::collections::HashMap<String, Box<dyn ::ttrpc::MethodHandler + Send + Sync>>;
 
+use crate::AttestationAgent;
+
 pub const AGENT_NAME: &str = "attestation-agent";
+
+#[cfg(feature = "ttrpc")]
+const PROTOCOL: &str = "ttrpc";
+#[cfg(feature = "grpc")]
+const PROTOCOL: &str = "grpc";
+
+lazy_static! {
+    pub static ref ABOUT: String = {
+        let aa_about = AttestationAgent::new().about();
+        format!("Protocol: {PROTOCOL}\n{aa_about}")
+    };
+}

--- a/app/src/ttrpc.rs
+++ b/app/src/ttrpc.rs
@@ -21,6 +21,7 @@ lazy_static! {
 pub fn ttrpc_main() {
     let app_matches = App::new(rpc::AGENT_NAME)
             .version(env!("CARGO_PKG_VERSION"))
+            .about(rpc::ABOUT.as_str())
             .arg(
                 Arg::with_name("KeyProvider ttRPC Unix socket addr")
                     .long("keyprovider_sock")

--- a/src/kbc_modules/mod.rs
+++ b/src/kbc_modules/mod.rs
@@ -136,6 +136,10 @@ impl KbcModuleList {
             })?;
         Ok(instantiate_func)
     }
+
+    pub fn names(&self) -> Vec<String> {
+        self.mod_list.keys().cloned().collect()
+    }
 }
 
 /// Descriptor for resources managed by attestation agent.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,11 @@ impl AttestationAgent {
         }
     }
 
+    pub fn about(&self) -> String {
+        let kbc_names_list = self.kbc_module_list.names().join(", ");
+        format!("KBCs: {kbc_names_list}")
+    }
+
     fn register_instance(&mut self, kbc_name: String, kbc_instance: KbcInstance) {
         self.kbc_instance_map.insert(kbc_name, kbc_instance);
     }


### PR DESCRIPTION
When running `attestation-agent --help`, print information about the protocol (grpc/ttrpc) and the built-in KBCs.

----

Example:

```
$ make KBC=online_sev_kbc,offline_fs_kbc,sample_kbc ttrpc=true
DEBIANOS is: true
cd app &&  cargo build --release --no-default-features --features " online_sev_kbc,offline_fs_kbc,sample_kbc ttrpc,rust-crypto" --target x86_64-unknown-linux-gnu
   Compiling attestation-agent v0.1.0 (/home/dubek/dev/attestation-agent/app)
    Finished release [optimized] target(s) in 3.33s

$ app/target/x86_64-unknown-linux-gnu/release/attestation-agent --help
attestation-agent 0.1.0
Protocol: ttrpc
KBCs: offline_fs_kbc, online_sev_kbc, sample_kbc

USAGE:
    attestation-agent [OPTIONS]

OPTIONS:
...
...
```

Cc: @fitzthum 