### PR TITLE
CC-KBC-TDX: Update detect_platform.

### DIFF
--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "base64 0.13.1",
  "cfg-if",
  "clap 3.2.23",
+ "const_format",
  "env_logger",
  "futures",
  "lazy_static",
@@ -434,6 +435,26 @@ name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
+name = "const_format"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "cookie"
@@ -2440,6 +2461,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"

--- a/src/kbc_modules/cc_kbc/attester/tdx/mod.rs
+++ b/src/kbc_modules/cc_kbc/attester/tdx/mod.rs
@@ -12,7 +12,7 @@ use tdx_attest_rs;
 const CCEL_PATH: &str = "/sys/firmware/acpi/tables/data/CCEL";
 
 pub fn detect_platform() -> bool {
-    Path::new("/dev/tdx-attest").exists()
+    Path::new("/dev/tdx-attest").exists() || Path::new("/dev/tdx-guest").exists()
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
In certain versions of the TDX guest kernel, due to interface changes, the `/dev/tdx-attest` driver has been renamed as the `/dev/tdx-guest` driver.