### PR TITLE
Make sure maximum attempt is equal with `KBS_GET_RESOURCE_MAX_ATTEMPT`

### DIFF
--- a/src/kbc_modules/cc_kbc/mod.rs
+++ b/src/kbc_modules/cc_kbc/mod.rs
@@ -182,8 +182,8 @@ impl Kbc {
     }
 
     async fn request_kbs_resource(&mut self, resource_url: String) -> Result<Response> {
-        for attempt in 1..=KBS_GET_RESOURCE_MAX_ATTEMPT {
-            log::info!("CC-KBC: trying to get resource, attempt {attempt}");
+        for attempt in 0..=KBS_GET_RESOURCE_MAX_ATTEMPT {
+            log::info!("CC-KBC: trying to get resource, attempt {}", attempt+1);
 
             if !self.authenticated {
                 self.establish_kbs_session().await?;


### PR DESCRIPTION
Originally,  it just try `KBS_GET_RESOURCE_MAX_ATTEMPT-1` times to get the resource.