### PR TITLE
Fix cckbc uri scheme

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -30,7 +30,7 @@ tonic-build = { version = "0.7.2", optional = true }
 ttrpc-codegen = { version = "0.4.1", optional = true }
 
 [features]
-default = ["sample_kbc", "grpc", "ttrpc"]
+default = ["sample_kbc", "ttrpc"]
 grpc = ["tokio", "tonic", "prost", "tonic-build"]
 ttrpc = ["dep:ttrpc", "ttrpc-codegen", "protobuf"]
 sample_kbc = ["attestation_agent/sample_kbc"]

--- a/app/src/rpc/getresource/mod.rs
+++ b/app/src/rpc/getresource/mod.rs
@@ -42,7 +42,8 @@ pub mod grpc {
             let target_resource = attestation_agent
                 .download_confidential_resource(
                     &request.kbc_name,
-                    &request.resource_uri,
+                    &request.resource_path,
+                    &request.kbs_uri,
                 )
                 .await
                 .map_err(|e| {
@@ -79,8 +80,8 @@ pub mod ttrpc {
     use crate::rpc::ttrpc_protocol::{getresource, getresource_ttrpc};
     use crate::rpc::TtrpcService;
     use crate::ttrpc::SYNC_ATTESTATION_AGENT;
-    use futures::executor::block_on;
     use ::ttrpc::proto::Code;
+    use futures::executor::block_on;
 
     impl getresource_ttrpc::GetResourceService for GetResource {
         fn get_resource(
@@ -103,7 +104,8 @@ pub mod ttrpc {
 
             let target_resource = block_on(attestation_agent.download_confidential_resource(
                 &req.KbcName,
-                &req.ResourceUri,
+                &req.ResourcePath,
+                &req.KbsUri,
             ))
             .map_err(|e| {
                 error!("Call AA-KBC to get resource failed: {}", e);

--- a/app/src/rpc/keyprovider/mod.rs
+++ b/app/src/rpc/keyprovider/mod.rs
@@ -146,8 +146,8 @@ pub mod ttrpc {
     use crate::rpc::ttrpc_protocol::{keyprovider, keyprovider_ttrpc};
     use crate::rpc::TtrpcService;
     use crate::ttrpc::SYNC_ATTESTATION_AGENT;
-    use futures::executor::block_on;
     use ::ttrpc::proto::Code;
+    use futures::executor::block_on;
     impl keyprovider_ttrpc::KeyProviderService for KeyProvider {
         fn un_wrap_key(
             &self,

--- a/app/src/ttrpc.rs
+++ b/app/src/ttrpc.rs
@@ -4,14 +4,22 @@
 //
 
 use super::*;
-use const_format::concatcp;
 use ::ttrpc::Server;
+use const_format::concatcp;
 use std::path::Path;
 
 const DEFAULT_UNIX_SOCKET_DIR: &str = "/run/confidential-containers/attestation-agent";
 const UNIX_SOCKET_PREFIX: &str = "unix://";
-const DEFAULT_KEYPROVIDER_SOCKET_ADDR: &str = concatcp!(UNIX_SOCKET_PREFIX, DEFAULT_UNIX_SOCKET_DIR, "keyprovider.sock");
-const DEFAULT_GETRESOURCE_SOCKET_ADDR: &str = concatcp!(UNIX_SOCKET_PREFIX, DEFAULT_UNIX_SOCKET_DIR, "getresource.sock");
+const DEFAULT_KEYPROVIDER_SOCKET_ADDR: &str = concatcp!(
+    UNIX_SOCKET_PREFIX,
+    DEFAULT_UNIX_SOCKET_DIR,
+    "keyprovider.sock"
+);
+const DEFAULT_GETRESOURCE_SOCKET_ADDR: &str = concatcp!(
+    UNIX_SOCKET_PREFIX,
+    DEFAULT_UNIX_SOCKET_DIR,
+    "getresource.sock"
+);
 
 lazy_static! {
     pub static ref SYNC_ATTESTATION_AGENT: Arc<std::sync::Mutex<AttestationAgent>> =

--- a/protos/getresource.proto
+++ b/protos/getresource.proto
@@ -3,8 +3,9 @@ syntax = "proto3";
 package getresource;
 
 message GetResourceRequest {
-    string ResourceUri = 1;
+    string ResourcePath = 1;
     string KbcName = 2;
+    string KbsUri = 3;
 }
 
 message GetResourceResponse {


### PR DESCRIPTION
When doing integration test, some bugs occurs and this pr can fix.
As the `reqwest` crate will not automatically try `http` when `https` fails, we must specify the KBS address by `aa_params`. That parameter will be delivered from the gRPC request.