### PR TITLE
Remote http method prefix in url creation

### DIFF
--- a/src/kbc_modules/cc_kbc/mod.rs
+++ b/src/kbc_modules/cc_kbc/mod.rs
@@ -231,7 +231,7 @@ impl Kbc {
         let r#type = &kid.r#type;
         let tag = &kid.tag;
         Ok(format!(
-            "http://{kbs_addr}/{KBS_URL_PREFIX}/resource/{repo}/{type}/{tag}"
+            "{kbs_addr}/{KBS_URL_PREFIX}/resource/{repo}/{type}/{tag}"
         ))
     }
 }


### PR DESCRIPTION
This might be a leftover from before the resource-uri refactoring, if I don't remove it, it will pass `/auth` and `/attest` http requests but fails at resource retrieval (when running `./tools/client`):

```
Error: error sending request for url (http://http//127.0.0.1:8080/kbs/v0/resource/my_repo/resource_type/123abc): error trying to connect: dns error: failed to lookup address information: Name or service not known
```