### PR TITLE
cc_kbc: Fix KBS URL handling

### DIFF
--- a/src/kbc_modules/mod.rs
+++ b/src/kbc_modules/mod.rs
@@ -85,8 +85,9 @@ impl KbcModuleList {
 
         #[cfg(feature = "cc_kbc")]
         {
-            let instantiate_func: KbcInstantiateFunc =
-                Box::new(|kbs_uri: String| -> KbcInstance { Box::new(cc_kbc::Kbc::new(kbs_uri)) });
+            let instantiate_func: KbcInstantiateFunc = Box::new(|kbs_uri: String| -> KbcInstance {
+                Box::new(cc_kbc::Kbc::new(kbs_uri).unwrap())
+            });
             mod_list.insert("cc_kbc".to_string(), instantiate_func);
         }
 

--- a/src/kbc_modules/uri.rs
+++ b/src/kbc_modules/uri.rs
@@ -15,10 +15,6 @@ const RESOURCE_ID_ERROR_INFO: &str =
 
 const SCHEME: &str = "kbs";
 
-/// If the kbs address inside a kbs resource uri does not have a port field,
-/// use this value as default. This value follows the CC-KBS implementation.
-const DEFAULT_KBS_PORT: u16 = 8080;
-
 /// Resource Id document <https://github.com/confidential-containers/attestation-agent/blob/main/docs/KBS_URI.md>
 #[derive(Clone, Debug, PartialEq)]
 pub struct ResourceUri {
@@ -44,9 +40,10 @@ impl TryFrom<url::Url> for ResourceUri {
         let mut addr = value.host_str().unwrap_or_default().to_string();
 
         if !addr.is_empty() {
-            let port = value.port().unwrap_or(DEFAULT_KBS_PORT).to_string();
-            addr += ":";
-            addr += &port;
+            if let Some(port) = value.port() {
+                addr += ":";
+                addr += &port.to_string();
+            }
         }
 
         if value.scheme() != SCHEME {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,12 +145,7 @@ impl AttestationAPIs for AttestationAgent {
         resource_path: &str,
         kbs_uri: &str,
     ) -> Result<Vec<u8>> {
-        let kbs_socket = match kbs_uri.split_once("://") {
-            Some((_, addr)) => addr.to_string(),
-            None => kbs_uri.to_string(),
-        };
-
-        let resource_uri = ResourceUri::new(&kbs_socket, resource_path)?;
+        let resource_uri = ResourceUri::new(kbs_uri, resource_path)?;
 
         if !self.kbc_instance_map.contains_key(kbc_name) {
             self.instantiate_kbc(kbc_name, kbs_uri)?;


### PR DESCRIPTION
The `cc_kbc` structure now carries the whole KBS URL, including scheme, host and port values.
We compare the KBS host value with the resource host address and bail if they don't match.