### PR TITLE
Use kbs types from crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ base64 = "0.13.0"
 bincode = { version = "1.3.3", optional = true }
 ctr = { version = "0.9.2", optional = true }
 foreign-types = { version = "0.5.0", optional = true }
-kbs-types = { git = "https://github.com/virtee/kbs-types" }
+kbs-types = "0.2"
 log = "0.4.14"
 openssl = { version = "0.10", features = ["vendored"], optional = true}
 prost = { version = "0.11.0", optional = true }

--- a/src/kbc_modules/cc_kbc/crypto/mod.rs
+++ b/src/kbc_modules/cc_kbc/crypto/mod.rs
@@ -40,8 +40,8 @@ impl TeeKey {
 
     // Export TEE public key as specific structure.
     pub fn export_pubkey(&self) -> Result<TeePubKey> {
-        let k_mod = self.public_key.n().to_string();
-        let k_exp = self.public_key.e().to_string();
+        let k_mod = base64::encode(self.public_key.n().to_bytes_be());
+        let k_exp = base64::encode(self.public_key.e().to_bytes_be());
 
         Ok(TeePubKey {
             alg: RSA_ALGORITHM.to_string(),

--- a/src/kbc_modules/cc_kbc/kbs_protocol/message.rs
+++ b/src/kbc_modules/cc_kbc/kbs_protocol/message.rs
@@ -40,18 +40,6 @@ pub struct Challenge {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Attestation {
-    // The public key of TEE.
-    // Its hash is included in `tee-evidence`.
-    #[serde(rename = "tee-pubkey")]
-    pub tee_pubkey: TeePubKey,
-
-    // TEE quote, different TEE type has different format of the content.
-    #[serde(rename = "tee-evidence")]
-    pub tee_evidence: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Response {
     pub protected: String,
     pub encrypted_key: String,

--- a/src/kbc_modules/cc_kbc/mod.rs
+++ b/src/kbc_modules/cc_kbc/mod.rs
@@ -18,7 +18,7 @@ use attester::{detect_tee_type, Attester};
 use core::time::Duration;
 use crypto::{hash_chunks, TeeKey};
 use kbs_protocol::message::*;
-use kbs_types::ErrorInformation;
+use kbs_types::{Attestation, ErrorInformation};
 use url::Url;
 use zeroize::Zeroizing;
 
@@ -111,7 +111,8 @@ impl Kbc {
 
         let ehd_chunks = vec![
             self.nonce.clone().into_bytes(),
-            tee_pubkey.k.clone().into_bytes(),
+            tee_pubkey.k_mod.clone().into_bytes(),
+            tee_pubkey.k_exp.clone().into_bytes(),
         ];
 
         let ehd = hash_chunks(ehd_chunks);


### PR DESCRIPTION
The pubkey logic needs to be adjusted to match the upstream virtee/kbs-types structs. The fix needs to be coupled with the respective PRs on [Attestation Service](https://github.com/confidential-containers/attestation-service/pull/78) and [KBS](https://github.com/confidential-containers/attestation-agent/pull/170).

Fixes confidential-containers/guest-components#206 