### PR TITLE
fix: automatically generated kid

### DIFF
--- a/coco_keyprovider/src/enc_mods/mod.rs
+++ b/coco_keyprovider/src/enc_mods/mod.rs
@@ -63,7 +63,7 @@ const HARD_CODED_KEYID: &str = "kbs:///default/test-key/1";
 
 /// When a KEK is randomly generated, a new kid will be generated
 /// with this prefix.
-const DEFAULT_KEY_REPO_PATH: &str = "default/image-kek";
+const DEFAULT_KEY_REPO_PATH: &str = "/default/image-kek";
 
 const KBS_RESOURCE_URL_PREFIX: &str = "kbs://";
 


### PR DESCRIPTION
When a kid is generated automatically, current inplementation will raise an error that the kid is not legal.