### PR TITLE
ci: release for coco keyprovider publishment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Cut Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push-images:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      -
+        name: Build and push coco-key-provider
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./docker/Dockerfile.keyprovider
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/confidential-containers/coco-keyprovider:${{ github.ref_name }}, ghcr.io/confidential-containers/coco-keyprovider:latest

--- a/docker/Dockerfile.keyprovider
+++ b/docker/Dockerfile.keyprovider
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get install protobuf-compiler -y && \
 
 COPY . .
 
+LABEL org.opencontainers.image.source="https://github.com/confidential-containers/attestation-agent"
+
 RUN cd coco_keyprovider && cargo install --path .
 
 FROM ubuntu:20.04


### PR DESCRIPTION
This github action should be triggered automatically to build a coco-keyprovider image and publish to ghcr.io

Close confidential-containers/guest-components#202