### PR TITLE
Let Rust lint CI cover all sub crates

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           command: clippy
           # We are getting error in generated code due to derive_partial_eq_without_eq check, so ignore it for now
-          args: -p attestation_agent --all-targets --features rust-crypto -- -D warnings -A clippy::derive_partial_eq_without_eq
+          args: --workspace -- -D warnings -A clippy::derive-partial-eq-without-eq

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -20,7 +20,7 @@ prost = { version = "0.10.4", optional = true }
 protobuf = { version = "3.1.0", optional = true }
 serde.workspace = true
 serde_json.workspace = true
-tokio = { version = "1.0", default-features = false, features = ["rt-multi-thread", "rt", "sync"]}
+tokio = { version = "1.0", default-features = false, features = ["rt-multi-thread", "rt", "sync", "signal"]}
 tonic = { version = "0.7.2", optional = true }
 ttrpc = { version = "0.7.1", features = ["async"], optional = true }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -33,6 +33,4 @@ async fn main() {
             compile_error!("one feature of `grpc` or `ttrpc` must be enabled.");
         }
     }
-
-    loop {}
 }

--- a/app/src/rpc/ttrpc_protocol/mod.rs
+++ b/app/src/rpc/ttrpc_protocol/mod.rs
@@ -4,6 +4,8 @@
 //
 
 pub mod getresource;
+#[allow(clippy::redundant_field_names)]
 pub mod getresource_ttrpc;
 pub mod keyprovider;
+#[allow(clippy::redundant_field_names)]
 pub mod keyprovider_ttrpc;

--- a/app/src/ttrpc.rs
+++ b/app/src/ttrpc.rs
@@ -62,9 +62,9 @@ pub async fn ttrpc_main() -> Result<()> {
         .value_of("GetResource ttRPC Unix socket addr")
         .unwrap_or(DEFAULT_GETRESOURCE_SOCKET_ADDR);
 
-    clean_previous_sock_file(&keyprovider_socket)
+    clean_previous_sock_file(keyprovider_socket)
         .context("clean previous keyprovider socket file")?;
-    clean_previous_sock_file(&getresource_socket)
+    clean_previous_sock_file(getresource_socket)
         .context("clean previous getresource socket file")?;
 
     let kp = rpc::keyprovider::ttrpc::start_ttrpc_service()?;


### PR DESCRIPTION
Now the Rust lint does not cover all  the sub crates, and I get the following errors when execute `cargo clippy` but they are not reported by CI

```
warning: redundant field names in struct initialization
  --> app/src/rpc/ttrpc_protocol/getresource_ttrpc.rs:33:13
   |
33 |             client: client,
   |             ^^^^^^^^^^^^^^ help: replace it with: `client`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
   = note: `#[warn(clippy::redundant_field_names)]` on by default

warning: redundant field names in struct initialization
  --> app/src/rpc/ttrpc_protocol/keyprovider_ttrpc.rs:33:13
   |
33 |             client: client,
   |             ^^^^^^^^^^^^^^ help: replace it with: `client`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> app/src/ttrpc.rs:62:30
   |
62 |     clean_previous_sock_file(&keyprovider_socket)
   |                              ^^^^^^^^^^^^^^^^^^^ help: change this to: `keyprovider_socket`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `#[warn(clippy::needless_borrow)]` on by default

warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> app/src/ttrpc.rs:64:30
   |
64 |     clean_previous_sock_file(&getresource_socket)
   |                              ^^^^^^^^^^^^^^^^^^^ help: change this to: `getresource_socket`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: empty `loop {}` wastes CPU cycles
  --> app/src/ttrpc.rs:92:5
   |
92 |     loop {}
   |     ^^^^^^^
   |
   = help: you should either use `panic!()` or add `std::thread::sleep(..);` to the loop body
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_loop
   = note: `#[warn(clippy::empty_loop)]` on by default

warning: empty `loop {}` wastes CPU cycles
  --> app/src/main.rs:37:5
   |
37 |     loop {}
   |     ^^^^^^^
   |
   = help: you should either use `panic!()` or add `std::thread::sleep(..);` to the loop body
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_loop

warning: `attestation-agent` (bin "attestation-agent") generated 6 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 3.65s
```