### PR TITLE
ci: delete useless dep installation for tdx

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -29,13 +29,6 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
-      - name: Install TDX dependencies
-        run: |
-          sudo curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-          sudo echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-          sudo apt-get update
-          sudo apt-get install -y libtdx-attest-dev
-
       - name: Build and install with default features
         run: |
           make && make install


### PR DESCRIPTION
basic CI will not build or do lint check for tdx-based features anymore, thus we do not need to install tdx dependencies in ci.