### PR TITLE
Rename Occlum attester to SGX attester and add Gramine support to it

### DIFF
--- a/.github/workflows/cc_kbc.yml
+++ b/.github/workflows/cc_kbc.yml
@@ -28,7 +28,7 @@ jobs:
         kbc:
           - cc_kbc
           - cc_kbc_tdx
-          - cc_kbc_occlum
+          - cc_kbc_sgx
           - cc_kbc_az_snp_vtpm
           - cc_kbc_snp
     steps:

--- a/.github/workflows/occlum_sgx.yml
+++ b/.github/workflows/occlum_sgx.yml
@@ -2,15 +2,15 @@ name: CC kbc build CI
 on:
   push:
     paths:
-      - 'attester/src/sgx_occlum'
+      - 'attester/src/sgx_dcap'
       - '.github/workflows/occlum_sgx.yml'
   pull_request:
     paths:
-      - 'attester/src/sgx_occlum'
+      - 'attester/src/sgx_dcap'
       - '.github/workflows/occlum_sgx.yml'
   create:
     paths:
-      - 'attester/src/sgx_occlum'
+      - 'attester/src/sgx_dcap'
       - '.github/workflows/occlum_sgx.yml'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ CC KBC supports different kinds of hardware TEE attesters, now
 | Attester name      |          Info             |
 | ------------------ |---------------------------|
 | tdx-attester       |Intel TDX                  |
-| occlum-attester    |Intel SGX with occlum libOS|
+| sgx-attester       |Intel SGX DCAP             |
 
 To build cc kbc with tdx and install, use
 ```shell

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -37,7 +37,7 @@ cc_kbc = ["attestation_agent/cc_kbc", "attestation_agent/all-attesters"]
 
 # attester suites of cc-kbc
 cc_kbc_tdx = ["attestation_agent/cc_kbc", "attestation_agent/tdx-attester"]
-cc_kbc_occlum = ["attestation_agent/cc_kbc","attestation_agent/occlum-attester"]
+cc_kbc_sgx = ["attestation_agent/cc_kbc","attestation_agent/sgx-attester"]
 cc_kbc_az_snp_vtpm = ["attestation_agent/cc_kbc", "attestation_agent/az-snp-vtpm-attester"]
 cc_kbc_snp = ["attestation_agent/cc_kbc", "attestation_agent/snp-attester"]
 

--- a/attester/Cargo.toml
+++ b/attester/Cargo.toml
@@ -19,9 +19,9 @@ tdx-attest-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimit
 
 [features]
 default = ["all-attesters"]
-all-attesters = ["tdx-attester", "occlum-attester", "az-snp-vtpm-attester", "snp-attester"]
+all-attesters = ["tdx-attester", "sgx-attester", "az-snp-vtpm-attester", "snp-attester"]
 
 tdx-attester = ["tdx-attest-rs"]
-occlum-attester = ["occlum_dcap"]
+sgx-attester = ["occlum_dcap"]
 az-snp-vtpm-attester = ["az-snp-vtpm"]
 snp-attester = ["sev"]

--- a/attester/src/lib.rs
+++ b/attester/src/lib.rs
@@ -16,15 +16,15 @@ pub mod az_snp_vtpm;
 #[cfg(feature = "tdx-attester")]
 pub mod tdx;
 
-#[cfg(feature = "occlum-attester")]
-pub mod sgx_occlum;
+#[cfg(feature = "sgx-attester")]
+pub mod sgx_dcap;
 
 #[cfg(feature = "snp-attester")]
 pub mod snp;
 
 /// The supported TEE types:
 /// - Tdx: TDX TEE.
-/// - SgxOcclum: SGX TEE with Occlum Libos.
+/// - Sgx: SGX TEE with a LibOS.
 /// - AzSnpVtpm: SEV-SNP TEE for Azure CVMs.
 /// - Snp: SEV-SNP TEE.
 /// - Sample: A dummy TEE that used to test/demo the KBC functionalities.
@@ -33,7 +33,7 @@ pub mod snp;
 pub enum Tee {
     Tdx,
     #[strum(serialize = "sgx")]
-    SgxOcclum,
+    Sgx,
     AzSnpVtpm,
     Snp,
     Sample,
@@ -46,8 +46,8 @@ impl Tee {
             Tee::Sample => Ok(Box::<sample::SampleAttester>::default()),
             #[cfg(feature = "tdx-attester")]
             Tee::Tdx => Ok(Box::<tdx::TdxAttester>::default()),
-            #[cfg(feature = "occlum-attester")]
-            Tee::SgxOcclum => Ok(Box::<sgx_occlum::SgxOcclumAttester>::default()),
+            #[cfg(feature = "sgx-attester")]
+            Tee::Sgx => Ok(Box::<sgx_dcap::SgxDcapAttester>::default()),
             #[cfg(feature = "az-snp-vtpm-attester")]
             Tee::AzSnpVtpm => Ok(Box::<az_snp_vtpm::AzSnpVtpmAttester>::default()),
             #[cfg(feature = "snp-attester")]
@@ -72,9 +72,9 @@ pub fn detect_tee_type() -> Tee {
         return Tee::Tdx;
     }
 
-    #[cfg(feature = "occlum-attester")]
-    if sgx_occlum::detect_platform() {
-        return Tee::SgxOcclum;
+    #[cfg(feature = "sgx-attester")]
+    if sgx_dcap::detect_platform() {
+        return Tee::Sgx;
     }
 
     #[cfg(feature = "az-snp-vtpm-attester")]

--- a/attester/src/sgx_dcap/mod.rs
+++ b/attester/src/sgx_dcap/mod.rs
@@ -15,19 +15,19 @@ pub fn detect_platform() -> bool {
 }
 
 #[derive(Serialize, Deserialize)]
-struct SgxOcclumAttesterEvidence {
+struct SgxDcapAttesterEvidence {
     /// Base64 encoded SGX quote.
     quote: String,
 }
 
 #[derive(Debug, Default)]
-pub struct SgxOcclumAttester {}
+pub struct SgxDcapAttester {}
 
-impl Attester for SgxOcclumAttester {
+impl Attester for SgxDcapAttester {
     fn get_evidence(&self, report_data: String) -> Result<String> {
         let mut report_data_bin = base64::decode(report_data)?;
         if report_data_bin.len() != 48 {
-            bail!("Occlum SGX Attester: Report data should be SHA384 base64 String");
+            bail!("SGX Attester: Report data should be SHA384 base64 String");
         }
 
         report_data_bin.extend([0; 16]);
@@ -42,12 +42,12 @@ impl Attester for SgxOcclumAttester {
             )
             .map_err(|e| anyhow!("generate quote: {e}"))?;
 
-        let evidence = SgxOcclumAttesterEvidence {
+        let evidence = SgxDcapAttesterEvidence {
             quote: base64::encode(quote),
         };
 
         serde_json::to_string(&evidence)
-            .map_err(|e| anyhow!("Serialize SGX-Occlum evidence failed: {:?}", e))
+            .map_err(|e| anyhow!("Serialize SGX DCAP Attester evidence failed: {:?}", e))
     }
 }
 
@@ -58,7 +58,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_sgx_get_evidence() {
-        let attester = SgxOcclumAttester::default();
+        let attester = SgxDcapAttester::default();
         let report_data: Vec<u8> = vec![0; 48];
         let report_data_base64 = base64::encode(report_data);
 

--- a/kbc/Cargo.toml
+++ b/kbc/Cargo.toml
@@ -39,7 +39,7 @@ default = ["sample_kbc", "rust-crypto"]
 cc_kbc = ["kbs_protocol"]
 all-attesters = ["kbs_protocol/all-attesters"]
 tdx-attester = ["kbs_protocol/tdx-attester"]
-occlum-attester = ["kbs_protocol/occlum-attester"]
+sgx-attester = ["kbs_protocol/sgx-attester"]
 az-snp-vtpm-attester= ["kbs_protocol/az-snp-vtpm-attester"]
 snp-attester = ["kbs_protocol/snp-attester"]
 

--- a/kbs_protocol/Cargo.toml
+++ b/kbs_protocol/Cargo.toml
@@ -23,7 +23,7 @@ zeroize.workspace = true
 default = ["all-attesters", "rust-crypto"]
 all-attesters = ["attester/all-attesters"]
 tdx-attester = ["attester/tdx-attester"]
-occlum-attester = ["attester/occlum-attester"]
+sgx-attester = ["attester/sgx-attester"]
 az-snp-vtpm-attester = ["attester/az-snp-vtpm-attester"]
 snp-attester = ["attester/snp-attester"]
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -25,7 +25,7 @@ default = ["sample_kbc", "rust-crypto"]
 cc_kbc = ["kbc/cc_kbc"]
 all-attesters = ["kbc/all-attesters"]
 tdx-attester = ["kbc/tdx-attester"]
-occlum-attester = ["kbc/occlum-attester"]
+sgx-attester = ["kbc/sgx-attester"]
 az-snp-vtpm-attester= ["kbc/az-snp-vtpm-attester"]
 snp-attester = ["kbc/snp-attester"]
 

--- a/test-binaries/Cargo.toml
+++ b/test-binaries/Cargo.toml
@@ -14,4 +14,4 @@ anyhow = "1.0"
 attester = { path = "../attester", default-features = false, optional = true }
 
 [features]
-occlum = ["attester/occlum-attester"]
+occlum = ["attester/sgx-attester"]

--- a/test-binaries/Cargo.toml
+++ b/test-binaries/Cargo.toml
@@ -12,6 +12,7 @@ required-features = ["occlum"]
 [dependencies]
 anyhow = "1.0"
 attester = { path = "../attester", default-features = false, optional = true }
+crypto = { path = "../deps/crypto" }
 
 [features]
 occlum = ["attester/sgx-attester"]

--- a/test-binaries/src/bin/occlum-attester.rs
+++ b/test-binaries/src/bin/occlum-attester.rs
@@ -5,10 +5,11 @@
 
 use anyhow::*;
 use attester::{sgx_dcap::SgxDcapAttester, Attester};
+use crypto::hash_chunks;
 
 fn real_main() -> Result<String> {
     let sgx_attester = SgxDcapAttester {};
-    sgx_attester.get_evidence("test".into())
+    sgx_attester.get_evidence(hash_chunks(vec!["test".as_bytes().to_vec()]))
 }
 
 fn main() {

--- a/test-binaries/src/bin/occlum-attester.rs
+++ b/test-binaries/src/bin/occlum-attester.rs
@@ -4,10 +4,10 @@
 //
 
 use anyhow::*;
-use attester::{sgx_occlum::SgxOcclumAttester, Attester};
+use attester::{sgx_dcap::SgxDcapAttester, Attester};
 
 fn real_main() -> Result<String> {
-    let sgx_attester = SgxOcclumAttester {};
+    let sgx_attester = SgxDcapAttester {};
     sgx_attester.get_evidence("test".into())
 }
 


### PR DESCRIPTION
WIP: I'm planning to change the existing `occlum-attester` to `sgx-dcap-attester`.

TODO:

- [x] rename feature names
- [x] rename structs/modules
- [x] rebase this PR