### PR TITLE
kbs_protocol: Return unquoted string from attestation()

### DIFF
--- a/kbs_protocol/src/lib.rs
+++ b/kbs_protocol/src/lib.rs
@@ -116,8 +116,8 @@ impl KbsProtocolWrapper {
         match attest_response.status() {
             reqwest::StatusCode::OK => {
                 self.authenticated = true;
-                let token = attest_response.json::<serde_json::Value>().await?["token"].to_string();
-                Ok(token)
+                let resp = attest_response.json::<AttestationResponseData>().await?;
+                Ok(resp.token)
             }
             reqwest::StatusCode::UNAUTHORIZED => {
                 let error_info = attest_response.json::<ErrorInformation>().await?;

--- a/kbs_protocol/src/types.rs
+++ b/kbs_protocol/src/types.rs
@@ -41,6 +41,12 @@ pub struct Challenge {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AttestationResponseData {
+    // Attestation token in JWT format
+    pub token: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Response {
     pub protected: String,
     pub encrypted_key: String,


### PR DESCRIPTION
Currently the String returned from attestation() is quoted, because Value["token"] is a Value, and to_string() returns the "string representation" of the Value instead of the contained string. Introduce a struct representing the data returned from /attest, and deserialize into that so that we return the correct, raw string.