### PR TITLE
ci: update occlum ci

### DIFF
--- a/.github/workflows/occlum_sgx.yml
+++ b/.github/workflows/occlum_sgx.yml
@@ -1,4 +1,4 @@
-name: CC kbc build CI
+name: CC kbc build CI (Occlum)
 on:
   push:
     paths:
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-and-run-occlum:
-    runs-on: self-hosted
+    runs-on: sgx-ecc
     container:
       image: occlum/occlum:latest-ubuntu20.04
       options: --device /dev/sgx_enclave --device /dev/sgx_provision


### PR DESCRIPTION
Use a different name to distinguish the CI of cc-kbc and the one with occlum. Also using the project's runner.