### PR TITLE
Document repo archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+THIS REPO IS NOW ARCHIVED.
+THE CODE IS HAS BEEN MERGED INTO https://github.com/confidential-containers/image-rs
+PLEASE OPEN ANY ISSUES OR PULL REQUESTS THERE.
+
+See https://github.com/confidential-containers/community/issues/89 for more background.
+
 # Attestation Agent
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fconfidential-containers%2Fattestation-agent.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fconfidential-containers%2Fattestation-agent?ref=badge_shield)
 


### PR DESCRIPTION
Development has shifted to the converged image-rs repo.

I can update that name with a new commit if we change the image-rs repo name. But I'd like to quickly redirect people so they don't waste time / get frustrated with this repo.